### PR TITLE
discovery: add rootless npm global path and allow wrapper fallback

### DIFF
--- a/src-tauri/src/utils/codex_discovery.rs
+++ b/src-tauri/src/utils/codex_discovery.rs
@@ -18,10 +18,23 @@ pub fn discover_codex_command() -> Option<PathBuf> {
     let home = std::env::var("HOME").unwrap_or_default();
     let binary_name = get_platform_binary_name();
     
+    // 0) Optional override via environment variable
+    if let Ok(explicit) = std::env::var("CODEX_PATH") {
+        let p = PathBuf::from(&explicit);
+        if p.exists() {
+            log_to_file(&format!("Using CODEX_PATH override at {}", p.display()));
+            return Some(p);
+        } else {
+            log_to_file(&format!("CODEX_PATH provided but not found: {}", explicit));
+        }
+    }
+    
     // First priority: Check actual binary locations in node_modules
     let binary_locations = [
         // Bun global installation
         format!("{}/.bun/install/global/node_modules/@openai/codex/bin/{}", home, binary_name),
+        // NPM rootless (user) global installation
+        format!("{}/.local/share/npm/lib/node_modules/@openai/codex/bin/{}", home, binary_name),
         // NPM global installations
         format!("/usr/local/lib/node_modules/@openai/codex/bin/{}", binary_name),
         format!("/opt/homebrew/lib/node_modules/@openai/codex/bin/{}", binary_name),
@@ -58,24 +71,33 @@ pub fn discover_codex_command() -> Option<PathBuf> {
         }
     }
 
-    // Final fallback: Check PATH for native binaries (but skip wrapper scripts)
+    // Final fallback: Check PATH for native binaries; prefer non-wrappers, but accept wrappers as last resort
     if let Ok(path_env) = std::env::var("PATH") {
         let separator = if cfg!(windows) { ';' } else { ':' };
+        let mut wrapper_candidate: Option<PathBuf> = None;
         for dir in path_env.split(separator) {
             if dir.is_empty() { continue; }
             let exe_name = if cfg!(windows) { "codex.exe" } else { "codex" };
             let candidate = PathBuf::from(dir).join(exe_name);
             if candidate.exists() {
-                // Try to verify it's not a wrapper
+                // Try to verify if it's a wrapper
                 if let Ok(content) = std::fs::read_to_string(&candidate) {
-                    if content.contains("codex.js") || content.starts_with("#!/usr/bin/env node") || content.contains("import") {
-                        log_to_file(&format!("Skipping wrapper script at {}", candidate.display()));
-                        continue; // Skip wrapper scripts
+                    let is_wrapper = content.contains("codex.js") || content.starts_with("#!/usr/bin/env node") || content.contains("import");
+                    if is_wrapper {
+                        // Keep as last-resort fallback
+                        wrapper_candidate = Some(candidate.clone());
+                        log_to_file(&format!("Found wrapper script candidate at {} (will use only if no native binary is found)", candidate.display()));
+                        continue; 
                     }
                 }
-                log_to_file(&format!("Found codex in PATH at {}", candidate.display()));
+                // Looks like a native binary
+                log_to_file(&format!("Found native codex in PATH at {}", candidate.display()));
                 return Some(candidate);
             }
+        }
+        if let Some(wrapper) = wrapper_candidate {
+            log_to_file(&format!("Using wrapper codex from PATH at {} as fallback", wrapper.display()));
+            return Some(wrapper);
         }
     }
 


### PR DESCRIPTION
This PR implements the minimal discovery improvements described in CODEX-DISCOVERY-FINDINGS.md:

- Add rootless npm global path to preferred search:
  - `~/.local/share/npm/lib/node_modules/@openai/codex/bin/<binary>`
- Prefer native binaries but allow wrapper shims as a last-resort fallback when scanning PATH
- Add optional `CODEX_PATH` env override for headless/debug usage

Motivation
- Default npm (rootless) installs were not detected without a manual symlink. This adds that path and reduces setup friction.
- In environments where only the npm wrapper exists in PATH, we now gracefully accept it if no native binary is found.

Verification
- `cargo check --manifest-path src-tauri/Cargo.toml` succeeds
- Local dev server runs (`vite` on a custom port) without impacting any existing Codexia installation

Scope
- Changes isolated to `src-tauri/src/utils/codex_discovery.rs`

Happy to iterate on naming or ordering if you prefer alternate precedence.