### PR TITLE
fix: handle tauri errors on macOS

### DIFF
--- a/src/components/filetree/FileTreeView.tsx
+++ b/src/components/filetree/FileTreeView.tsx
@@ -7,6 +7,7 @@ import { useContextFilesStore } from "@/stores/ContextFilesStore";
 import { useFileTokens } from "@/hooks/useFileTokens";
 import { FileTreeHeader } from "./FileTreeHeader";
 import { FileTreeItem } from "./FileTreeItem";
+import { getErrorMessage } from "@/utils/errorUtils";
 
 interface FileEntry {
   name: string;
@@ -64,7 +65,7 @@ export function FileTree({
       });
       setEntries(result);
     } catch (err) {
-      setError(err as string);
+      setError(getErrorMessage(err));
     } finally {
       setLoading(false);
     }

--- a/src/components/filetree/FileViewer.tsx
+++ b/src/components/filetree/FileViewer.tsx
@@ -9,6 +9,7 @@ import { useThemeStore } from "@/stores/ThemeStore";
 import { useConversationStore } from "@/stores/ConversationStore";
 import { useLayoutStore } from "@/stores/layoutStore";
 import { useChatInputStore } from "@/stores/chatInputStore";
+import { getErrorMessage } from "@/utils/errorUtils";
 
 interface FileViewerProps {
   filePath: string | null;
@@ -89,7 +90,7 @@ export function FileViewer({ filePath, onClose, addToNotepad }: FileViewerProps)
       setCurrentContent(fileContent);
       setDiskChanged(false);
     } catch (err) {
-      setError(err as string);
+      setError(getErrorMessage(err));
     } finally {
       setLoading(false);
     }

--- a/src/components/filetree/GitStatusView.tsx
+++ b/src/components/filetree/GitStatusView.tsx
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { useFolderStore } from "@/stores/FolderStore";
 import { RefreshCw, GitBranch, FileText } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { getErrorMessage } from "@/utils/errorUtils";
 
 interface GitStatus {
 	staged: string[];
@@ -45,8 +46,8 @@ export function GitStatusView({ currentFolder, onDiffClick }: GitStatusViewProps
 				directory: targetPath,
 			});
 			setGitStatus(result);
-		} catch (err) {
-			setError(err as string);
+                } catch (err) {
+                        setError(getErrorMessage(err));
 		} finally {
 			setLoading(false);
 		}

--- a/src/components/usage/TokenDistributionChart.tsx
+++ b/src/components/usage/TokenDistributionChart.tsx
@@ -37,7 +37,13 @@ export function TokenDistributionChart({ usageData, formatTokens }: TokenDistrib
                 cx="50%"
                 cy="50%"
                 labelLine={false}
-                label={({ name, percent }) => `${name} ${(percent ? percent * 100 : 0).toFixed(0)}%`}
+                label={({ name, percent }) => {
+                  const percentage =
+                    typeof percent === "number"
+                      ? (percent * 100).toFixed(0)
+                      : "0";
+                  return `${name} ${percentage}%`;
+                }}
                 outerRadius={80}
                 fill="#8884d8"
                 dataKey="value"

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -1,0 +1,16 @@
+export function getErrorMessage(error: unknown): string {
+  if (typeof error === "string") {
+    return error;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch (jsonError) {
+    console.error("Failed to stringify error:", jsonError);
+    return String(error);
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared helper to normalize error objects coming back from tauri invocations
- use the helper when loading the file tree, file viewer, and git status panes so React never receives raw objects
- harden the token distribution chart label logic to cope with non-numeric percent values

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfca7473c483228494d12730cf6528

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages in File Viewer, File Tree, and Git Status to display meaningful details.
  * Fixed Token Distribution chart labels to correctly handle non-numeric percentages and avoid invalid values.

* **Refactor**
  * Standardized error handling across components using a centralized utility for consistent and reliable messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->