### PR TITLE
Fixed an issue with transient PowerShell windows on Windows builds

### DIFF
--- a/src-tauri/src/codex/app_server.rs
+++ b/src-tauri/src/codex/app_server.rs
@@ -5,8 +5,6 @@ use codex_app_server_protocol::{
 };
 use serde_json::Value;
 use std::collections::HashMap;
-#[cfg(target_os = "windows")]
-use std::os::windows::process::CommandExt;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -14,6 +12,9 @@ use tokio::process::{ChildStdin, Command};
 use tokio::sync::{Mutex, oneshot};
 
 use codex_finder::discover_codex_command;
+
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
 pub struct CodexAppServer {
     stdin: Mutex<ChildStdin>,
@@ -85,6 +86,8 @@ pub async fn connect_codex(event_sink: Arc<dyn EventSink>) -> Result<Arc<CodexAp
     command.stdin(std::process::Stdio::piped());
     command.stdout(std::process::Stdio::piped());
     command.stderr(std::process::Stdio::piped());
+    #[cfg(target_os = "windows")]
+    command.creation_flags(CREATE_NO_WINDOW);
 
     let mut child = command.spawn().map_err(|e| e.to_string())?;
     let stdin = child.stdin.take().ok_or("missing stdin")?;

--- a/src-tauri/src/gui.rs
+++ b/src-tauri/src/gui.rs
@@ -167,14 +167,24 @@ pub fn run() {
             #[cfg(debug_assertions)]
             {
                 use std::process::Command;
+                #[cfg(target_os = "windows")]
+                use std::os::windows::process::CommandExt;
 
-                let status = Command::new("codex")
+                #[cfg(target_os = "windows")]
+                const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+                let mut command = Command::new("codex");
+                command
                     .args(["app-server", "generate-ts", "-o", "src/bindings"])
                     .current_dir(
                         std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
                             .parent()
                             .expect("Failed to get project root"),
-                    )
+                    );
+                #[cfg(target_os = "windows")]
+                command.creation_flags(CREATE_NO_WINDOW);
+
+                let status = command
                     .status()
                     .expect("Failed to run codex app-server generate-ts");
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -59,7 +59,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "createUpdaterArtifacts": true,
+    "createUpdaterArtifacts": false,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
 useGitWatch now creates them with the NO_WINDOW flag. Did the same in app_server.rs too preemptively.