### PR TITLE
feat: URL-param deep-link + clickable session-manager rows

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { invoke } from '@tauri-apps/api/core';
 import './App.css';
 import { useCodexEvents } from '@/hooks/codex';
 import { useDeepLink } from '@/hooks/useDeepLink';
+import { useUrlParamThread } from '@/hooks/useUrlParamThread';
 import { AppLayout } from '@/components/layout';
 import { isTauri, getIsPhone } from '@/hooks/runtime';
 const LoginView = lazy(() => import('@/views/LoginView'));
@@ -105,6 +106,9 @@ function AppShell() {
 
   // Listen to codex events only after backend is initialized
   useCodexEvents(codexReady);
+
+  // Web-mode deep link: ?agent=codex&thread=<id>&cwd=<path> (or agent=cc&session=<id>)
+  useUrlParamThread(codexReady);
 
   // Wait for platform detection and settings load before rendering
   if (isPhone === null || !settingsReady) return null;

--- a/src/components/layout/SessionManagerDialog.tsx
+++ b/src/components/layout/SessionManagerDialog.tsx
@@ -1,12 +1,16 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Trash2, Search, CheckSquare, Square } from 'lucide-react';
 import { getSessions, SessionData } from '@/lib/sessions';
-import { ccDeleteSession } from '@/services/tauri/cc';
+import { ccDeleteSession, ccGetSessionFilePath } from '@/services/tauri/cc';
 import { deleteFile } from '@/services/tauri';
+import { readTextFileLines } from '@/services/tauri/filesystem';
+import { parseSessionJsonl } from '@/components/cc/utils/parseSessionJsonl';
 import type { ThreadListItem } from '@/types/codex/ThreadListItem';
 import { codexService } from '@/services/codexService';
 import { useCodexStore, useThreadListStore } from '@/stores/codex';
 import { useWorkspaceStore } from '@/stores/useWorkspaceStore';
+import { useCCStore } from '@/stores/cc';
+import { useLayoutStore, useAgentCenterStore } from '@/stores';
 import { AgentIcon } from '@/components/common/AgentIcon';
 import { formatThreadAge } from '@/utils/formatThreadAge';
 import { getFilename } from '@/utils/getFilename';
@@ -72,9 +76,9 @@ export function SessionManagerDialog({ open, onOpenChange, defaultTab = 'cc' }: 
 
         <div className="flex flex-col flex-1 min-h-0 px-4 pb-4 pt-3">
           {activeTab === 'cc' ? (
-            <CCSessionManager />
+            <CCSessionManager onClose={() => onOpenChange(false)} />
           ) : (
-            <CodexThreadManager />
+            <CodexThreadManager onClose={() => onOpenChange(false)} />
           )}
         </div>
       </DialogContent>
@@ -84,13 +88,40 @@ export function SessionManagerDialog({ open, onOpenChange, defaultTab = 'cc' }: 
 
 // ── CC Session Manager ────────────────────────────────────────────────────────
 
-function CCSessionManager() {
+function CCSessionManager({ onClose }: { onClose: () => void }) {
   const [sessions, setSessions] = useState<SessionData[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [pendingDeleteIds, setPendingDeleteIds] = useState<string[] | null>(null);
   const { toast } = useToast();
+  const { cwd, setCwd, setSelectedAgent } = useWorkspaceStore();
+  const { setView } = useLayoutStore();
+  const { addAgentCard, setCurrentAgentCardId } = useAgentCenterStore();
+  const { sessionMessagesMap, addMessageToSession, setSessionLoading } = useCCStore();
+
+  const handleOpenSession = (session: SessionData) => {
+    if (session.project && session.project !== cwd) {
+      setCwd(session.project);
+    }
+    setSelectedAgent('cc');
+    addAgentCard({ kind: 'cc', id: session.sessionId, preview: session.display, cwd: session.project || cwd });
+    setCurrentAgentCardId(session.sessionId);
+    setView('agent');
+    const sid = session.sessionId;
+    if (!sessionMessagesMap[sid]?.length) {
+      void (async () => {
+        const filePath = await ccGetSessionFilePath(sid);
+        if (!filePath) return;
+        const lines = await readTextFileLines(filePath);
+        for (const msg of parseSessionJsonl(lines, sid)) {
+          addMessageToSession(sid, msg);
+        }
+        setSessionLoading(sid, false);
+      })();
+    }
+    onClose();
+  };
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -177,13 +208,23 @@ function CCSessionManager() {
           filtered.map((session) => (
             <div
               key={session.sessionId}
-              className="flex items-center gap-3 px-2 py-1.5 rounded-md hover:bg-accent/40 group"
+              role="button"
+              tabIndex={0}
+              className="flex items-center gap-3 px-2 py-1.5 rounded-md hover:bg-accent/40 group cursor-pointer"
+              onClick={() => handleOpenSession(session)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handleOpenSession(session);
+                }
+              }}
             >
-              <Checkbox
-                checked={selectedIds.has(session.sessionId)}
-                onCheckedChange={() => toggle(session.sessionId)}
-                className="shrink-0"
-              />
+              <div onClick={(e) => e.stopPropagation()} className="shrink-0">
+                <Checkbox
+                  checked={selectedIds.has(session.sessionId)}
+                  onCheckedChange={() => toggle(session.sessionId)}
+                />
+              </div>
               <div className="flex-1 min-w-0">
                 <div className="text-sm font-medium truncate">{session.display}</div>
                 <div className="text-xs text-muted-foreground truncate">{getFilename(session.project) || session.project}</div>
@@ -195,7 +236,10 @@ function CCSessionManager() {
                 variant="ghost"
                 size="icon"
                 className="h-6 w-6 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive shrink-0"
-                onClick={() => setPendingDeleteIds([session.sessionId])}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setPendingDeleteIds([session.sessionId]);
+                }}
               >
                 <Trash2 className="h-3.5 w-3.5" />
               </Button>
@@ -221,14 +265,28 @@ function CCSessionManager() {
 
 // ── Codex Thread Manager ──────────────────────────────────────────────────────
 
-function CodexThreadManager() {
+function CodexThreadManager({ onClose }: { onClose: () => void }) {
   const { threads, currentThreadId } = useCodexStore();
   const { sortKey } = useThreadListStore();
-  const { cwd } = useWorkspaceStore();
+  const { cwd, setCwd } = useWorkspaceStore();
+  const { setView } = useLayoutStore();
+  const { addAgentCard, setCurrentAgentCardId } = useAgentCenterStore();
   const [search, setSearch] = useState('');
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [pendingDeleteItems, setPendingDeleteItems] = useState<ThreadListItem[] | null>(null);
   const { toast } = useToast();
+
+  const handleOpenThread = async (thread: ThreadListItem) => {
+    const targetCwd = thread.cwd || cwd;
+    if (targetCwd && targetCwd !== cwd) {
+      setCwd(targetCwd);
+    }
+    addAgentCard({ kind: 'codex', id: thread.id, preview: thread.preview, cwd: targetCwd });
+    setCurrentAgentCardId(thread.id);
+    setView('agent');
+    onClose();
+    await codexService.setCurrentThread(thread.id, { resume: true });
+  };
 
   // Load full thread list on mount
   useEffect(() => {
@@ -310,13 +368,23 @@ function CodexThreadManager() {
           filtered.map((thread) => (
             <div
               key={thread.id}
-              className="flex items-center gap-3 px-2 py-1.5 rounded-md hover:bg-accent/40 group"
+              role="button"
+              tabIndex={0}
+              className="flex items-center gap-3 px-2 py-1.5 rounded-md hover:bg-accent/40 group cursor-pointer"
+              onClick={() => void handleOpenThread(thread)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  void handleOpenThread(thread);
+                }
+              }}
             >
-              <Checkbox
-                checked={selectedIds.has(thread.id)}
-                onCheckedChange={() => toggle(thread.id)}
-                className="shrink-0"
-              />
+              <div onClick={(e) => e.stopPropagation()} className="shrink-0">
+                <Checkbox
+                  checked={selectedIds.has(thread.id)}
+                  onCheckedChange={() => toggle(thread.id)}
+                />
+              </div>
               <div className="flex-1 min-w-0">
                 <div className="text-sm font-medium truncate">{thread.preview || thread.id}</div>
                 <div className="text-xs text-muted-foreground truncate">{getFilename(thread.cwd) || thread.cwd}</div>
@@ -328,7 +396,10 @@ function CodexThreadManager() {
                 variant="ghost"
                 size="icon"
                 className="h-6 w-6 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive shrink-0"
-                onClick={() => setPendingDeleteItems([thread])}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setPendingDeleteItems([thread]);
+                }}
               >
                 <Trash2 className="h-3.5 w-3.5" />
               </Button>

--- a/src/components/layout/SessionManagerDialog.tsx
+++ b/src/components/layout/SessionManagerDialog.tsx
@@ -7,7 +7,6 @@ import { readTextFileLines } from '@/services/tauri/filesystem';
 import { parseSessionJsonl } from '@/components/cc/utils/parseSessionJsonl';
 import type { ThreadListItem } from '@/types/codex/ThreadListItem';
 import { codexService } from '@/services/codexService';
-import { isGitRepo } from '@/services/tauri/git';
 import { useCodexStore, useThreadListStore } from '@/stores/codex';
 import { useWorkspaceStore } from '@/stores/useWorkspaceStore';
 import { useCCStore } from '@/stores/cc';
@@ -101,13 +100,9 @@ function CCSessionManager({ onClose }: { onClose: () => void }) {
   const { addAgentCard, setCurrentAgentCardId } = useAgentCenterStore();
   const { sessionMessagesMap, addMessageToSession, setSessionLoading } = useCCStore();
 
-  const handleOpenSession = async (session: SessionData) => {
+  const handleOpenSession = (session: SessionData) => {
     if (session.project && session.project !== cwd) {
-      if (await isGitRepo(session.project)) {
-        setCwd(session.project);
-      } else {
-        toast({ description: `Session cwd '${session.project}' isn't a git repo — keeping current project.` });
-      }
+      setCwd(session.project);
     }
     setSelectedAgent('cc');
     addAgentCard({ kind: 'cc', id: session.sessionId, preview: session.display, cwd: session.project || cwd });
@@ -216,11 +211,11 @@ function CCSessionManager({ onClose }: { onClose: () => void }) {
               role="button"
               tabIndex={0}
               className="flex items-center gap-3 px-2 py-1.5 rounded-md hover:bg-accent/40 group cursor-pointer"
-              onClick={() => void handleOpenSession(session)}
+              onClick={() => handleOpenSession(session)}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
-                  void handleOpenSession(session);
+                  handleOpenSession(session);
                 }
               }}
             >
@@ -284,11 +279,7 @@ function CodexThreadManager({ onClose }: { onClose: () => void }) {
   const handleOpenThread = async (thread: ThreadListItem) => {
     const targetCwd = thread.cwd || cwd;
     if (targetCwd && targetCwd !== cwd) {
-      if (await isGitRepo(targetCwd)) {
-        setCwd(targetCwd);
-      } else {
-        toast({ description: `Thread cwd '${targetCwd}' isn't a git repo — keeping current project.` });
-      }
+      setCwd(targetCwd);
     }
     addAgentCard({ kind: 'codex', id: thread.id, preview: thread.preview, cwd: targetCwd });
     setCurrentAgentCardId(thread.id);

--- a/src/components/layout/SessionManagerDialog.tsx
+++ b/src/components/layout/SessionManagerDialog.tsx
@@ -7,6 +7,7 @@ import { readTextFileLines } from '@/services/tauri/filesystem';
 import { parseSessionJsonl } from '@/components/cc/utils/parseSessionJsonl';
 import type { ThreadListItem } from '@/types/codex/ThreadListItem';
 import { codexService } from '@/services/codexService';
+import { isGitRepo } from '@/services/tauri/git';
 import { useCodexStore, useThreadListStore } from '@/stores/codex';
 import { useWorkspaceStore } from '@/stores/useWorkspaceStore';
 import { useCCStore } from '@/stores/cc';
@@ -100,9 +101,13 @@ function CCSessionManager({ onClose }: { onClose: () => void }) {
   const { addAgentCard, setCurrentAgentCardId } = useAgentCenterStore();
   const { sessionMessagesMap, addMessageToSession, setSessionLoading } = useCCStore();
 
-  const handleOpenSession = (session: SessionData) => {
+  const handleOpenSession = async (session: SessionData) => {
     if (session.project && session.project !== cwd) {
-      setCwd(session.project);
+      if (await isGitRepo(session.project)) {
+        setCwd(session.project);
+      } else {
+        toast({ description: `Session cwd '${session.project}' isn't a git repo — keeping current project.` });
+      }
     }
     setSelectedAgent('cc');
     addAgentCard({ kind: 'cc', id: session.sessionId, preview: session.display, cwd: session.project || cwd });
@@ -211,11 +216,11 @@ function CCSessionManager({ onClose }: { onClose: () => void }) {
               role="button"
               tabIndex={0}
               className="flex items-center gap-3 px-2 py-1.5 rounded-md hover:bg-accent/40 group cursor-pointer"
-              onClick={() => handleOpenSession(session)}
+              onClick={() => void handleOpenSession(session)}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
-                  handleOpenSession(session);
+                  void handleOpenSession(session);
                 }
               }}
             >
@@ -279,7 +284,11 @@ function CodexThreadManager({ onClose }: { onClose: () => void }) {
   const handleOpenThread = async (thread: ThreadListItem) => {
     const targetCwd = thread.cwd || cwd;
     if (targetCwd && targetCwd !== cwd) {
-      setCwd(targetCwd);
+      if (await isGitRepo(targetCwd)) {
+        setCwd(targetCwd);
+      } else {
+        toast({ description: `Thread cwd '${targetCwd}' isn't a git repo — keeping current project.` });
+      }
     }
     addAgentCard({ kind: 'codex', id: thread.id, preview: thread.preview, cwd: targetCwd });
     setCurrentAgentCardId(thread.id);

--- a/src/components/layout/SideBar.tsx
+++ b/src/components/layout/SideBar.tsx
@@ -1,4 +1,4 @@
-import { BarChart2, ListFilter, Lock, Package2, Timer, Trash2 } from 'lucide-react';
+import { BarChart2, History, ListFilter, Lock, Package2, Timer } from 'lucide-react';
 import { useAgentLimit } from '@/hooks/useAgentLimit';
 import { useCallback, useState } from 'react';
 import { useLayoutStore } from '@/stores';
@@ -144,7 +144,7 @@ export function SideBar() {
                 title="Manage sessions & threads"
                 onClick={() => setSessionManagerOpen(true)}
               >
-                <Trash2 className="h-4 w-4" />
+                <History className="h-4 w-4" />
               </Button>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>

--- a/src/hooks/useUrlParamThread.ts
+++ b/src/hooks/useUrlParamThread.ts
@@ -6,7 +6,6 @@ import { useCCStore } from '@/stores/cc';
 import { ccGetSessionFilePath } from '@/services/tauri/cc';
 import { readTextFileLines } from '@/services/tauri/filesystem';
 import { parseSessionJsonl } from '@/components/cc/utils/parseSessionJsonl';
-import { isGitRepo } from '@/services/tauri/git';
 
 let processed = false;
 
@@ -41,32 +40,25 @@ export function useUrlParamThread(enabled: boolean): void {
 
     if (!hasAgentNav) return;
 
-    void (async () => {
-      // Only switch cwd if the target is a git repo. Otherwise codexia's
-      // git pollers (useGitWatch consumers) loop on errors. Sessions can
-      // still open into the user's current project context.
-      if (await isGitRepo(cwd!)) {
-        addProject(cwd!);
-        setCwd(cwd!);
-      } else {
-        console.warn(`[useUrlParamThread] cwd '${cwd}' isn't a git repo — keeping current cwd.`);
-      }
+    addProject(cwd!);
+    setCwd(cwd!);
 
-      if (agent === 'codex' && threadId) {
-        setSelectedAgent('codex');
-        setActiveSidebarTab('codex');
-        addAgentCard({ kind: 'codex', id: threadId, cwd });
-        setCurrentAgentCardId(threadId);
-        setView('agent');
-        void codexService.setCurrentThread(threadId, { resume: true });
-      } else if (agent === 'cc' && sessionId) {
-        setSelectedAgent('cc');
-        setActiveSidebarTab('cc');
-        addAgentCard({ kind: 'cc', id: sessionId, cwd });
-        setCurrentAgentCardId(sessionId);
-        setView('agent');
-        const { sessionMessagesMap, addMessageToSession, setSessionLoading } = useCCStore.getState();
-        if (!sessionMessagesMap[sessionId]?.length) {
+    if (agent === 'codex' && threadId) {
+      setSelectedAgent('codex');
+      setActiveSidebarTab('codex');
+      addAgentCard({ kind: 'codex', id: threadId, cwd });
+      setCurrentAgentCardId(threadId);
+      setView('agent');
+      void codexService.setCurrentThread(threadId, { resume: true });
+    } else if (agent === 'cc' && sessionId) {
+      setSelectedAgent('cc');
+      setActiveSidebarTab('cc');
+      addAgentCard({ kind: 'cc', id: sessionId, cwd });
+      setCurrentAgentCardId(sessionId);
+      setView('agent');
+      const { sessionMessagesMap, addMessageToSession, setSessionLoading } = useCCStore.getState();
+      if (!sessionMessagesMap[sessionId]?.length) {
+        void (async () => {
           const filePath = await ccGetSessionFilePath(sessionId);
           if (!filePath) return;
           const lines = await readTextFileLines(filePath);
@@ -74,8 +66,8 @@ export function useUrlParamThread(enabled: boolean): void {
             addMessageToSession(sessionId, msg);
           }
           setSessionLoading(sessionId, false);
-        }
+        })();
       }
-    })();
+    }
   }, [enabled]);
 }

--- a/src/hooks/useUrlParamThread.ts
+++ b/src/hooks/useUrlParamThread.ts
@@ -6,6 +6,7 @@ import { useCCStore } from '@/stores/cc';
 import { ccGetSessionFilePath } from '@/services/tauri/cc';
 import { readTextFileLines } from '@/services/tauri/filesystem';
 import { parseSessionJsonl } from '@/components/cc/utils/parseSessionJsonl';
+import { isGitRepo } from '@/services/tauri/git';
 
 let processed = false;
 
@@ -40,25 +41,32 @@ export function useUrlParamThread(enabled: boolean): void {
 
     if (!hasAgentNav) return;
 
-    addProject(cwd!);
-    setCwd(cwd!);
+    void (async () => {
+      // Only switch cwd if the target is a git repo. Otherwise codexia's
+      // git pollers (useGitWatch consumers) loop on errors. Sessions can
+      // still open into the user's current project context.
+      if (await isGitRepo(cwd!)) {
+        addProject(cwd!);
+        setCwd(cwd!);
+      } else {
+        console.warn(`[useUrlParamThread] cwd '${cwd}' isn't a git repo — keeping current cwd.`);
+      }
 
-    if (agent === 'codex' && threadId) {
-      setSelectedAgent('codex');
-      setActiveSidebarTab('codex');
-      addAgentCard({ kind: 'codex', id: threadId, cwd });
-      setCurrentAgentCardId(threadId);
-      setView('agent');
-      void codexService.setCurrentThread(threadId, { resume: true });
-    } else if (agent === 'cc' && sessionId) {
-      setSelectedAgent('cc');
-      setActiveSidebarTab('cc');
-      addAgentCard({ kind: 'cc', id: sessionId, cwd });
-      setCurrentAgentCardId(sessionId);
-      setView('agent');
-      const { sessionMessagesMap, addMessageToSession, setSessionLoading } = useCCStore.getState();
-      if (!sessionMessagesMap[sessionId]?.length) {
-        void (async () => {
+      if (agent === 'codex' && threadId) {
+        setSelectedAgent('codex');
+        setActiveSidebarTab('codex');
+        addAgentCard({ kind: 'codex', id: threadId, cwd });
+        setCurrentAgentCardId(threadId);
+        setView('agent');
+        void codexService.setCurrentThread(threadId, { resume: true });
+      } else if (agent === 'cc' && sessionId) {
+        setSelectedAgent('cc');
+        setActiveSidebarTab('cc');
+        addAgentCard({ kind: 'cc', id: sessionId, cwd });
+        setCurrentAgentCardId(sessionId);
+        setView('agent');
+        const { sessionMessagesMap, addMessageToSession, setSessionLoading } = useCCStore.getState();
+        if (!sessionMessagesMap[sessionId]?.length) {
           const filePath = await ccGetSessionFilePath(sessionId);
           if (!filePath) return;
           const lines = await readTextFileLines(filePath);
@@ -66,8 +74,8 @@ export function useUrlParamThread(enabled: boolean): void {
             addMessageToSession(sessionId, msg);
           }
           setSessionLoading(sessionId, false);
-        })();
+        }
       }
-    }
+    })();
   }, [enabled]);
 }

--- a/src/hooks/useUrlParamThread.ts
+++ b/src/hooks/useUrlParamThread.ts
@@ -1,0 +1,73 @@
+import { useEffect } from 'react';
+import { codexService } from '@/services/codexService';
+import { useWorkspaceStore } from '@/stores/useWorkspaceStore';
+import { useLayoutStore, useAgentCenterStore } from '@/stores';
+import { useCCStore } from '@/stores/cc';
+import { ccGetSessionFilePath } from '@/services/tauri/cc';
+import { readTextFileLines } from '@/services/tauri/filesystem';
+import { parseSessionJsonl } from '@/components/cc/utils/parseSessionJsonl';
+
+let processed = false;
+
+// Reads ?agent=codex&thread=<id>&cwd=<path> or ?agent=cc&session=<id>&cwd=<path>
+// from the page URL on first mount and dispatches the same store updates that
+// a sidebar row click does. Used by external launchers (e.g. rejoin) to deep-link
+// into a specific session in web mode.
+export function useUrlParamThread(enabled: boolean): void {
+  useEffect(() => {
+    if (!enabled || processed) return;
+    if (typeof window === 'undefined') return;
+
+    const params = new URLSearchParams(window.location.search);
+    const agent = params.get('agent');
+    const cwd = params.get('cwd');
+    const threadId = params.get('thread');
+    const sessionId = params.get('session');
+    const projectsToAdd = params.getAll('addProject').filter(Boolean);
+    const hasAgentNav = !!agent && !!cwd && (agent === 'codex' || agent === 'cc');
+    if (!hasAgentNav && projectsToAdd.length === 0) return;
+
+    processed = true;
+
+    const cleanUrl = window.location.origin + window.location.pathname + window.location.hash;
+    window.history.replaceState({}, '', cleanUrl);
+
+    const { addProject, setCwd, setSelectedAgent } = useWorkspaceStore.getState();
+    const { setView, setActiveSidebarTab } = useLayoutStore.getState();
+    const { addAgentCard, setCurrentAgentCardId } = useAgentCenterStore.getState();
+
+    for (const p of projectsToAdd) addProject(p);
+
+    if (!hasAgentNav) return;
+
+    addProject(cwd!);
+    setCwd(cwd!);
+
+    if (agent === 'codex' && threadId) {
+      setSelectedAgent('codex');
+      setActiveSidebarTab('codex');
+      addAgentCard({ kind: 'codex', id: threadId, cwd });
+      setCurrentAgentCardId(threadId);
+      setView('agent');
+      void codexService.setCurrentThread(threadId, { resume: true });
+    } else if (agent === 'cc' && sessionId) {
+      setSelectedAgent('cc');
+      setActiveSidebarTab('cc');
+      addAgentCard({ kind: 'cc', id: sessionId, cwd });
+      setCurrentAgentCardId(sessionId);
+      setView('agent');
+      const { sessionMessagesMap, addMessageToSession, setSessionLoading } = useCCStore.getState();
+      if (!sessionMessagesMap[sessionId]?.length) {
+        void (async () => {
+          const filePath = await ccGetSessionFilePath(sessionId);
+          if (!filePath) return;
+          const lines = await readTextFileLines(filePath);
+          for (const msg of parseSessionJsonl(lines, sessionId)) {
+            addMessageToSession(sessionId, msg);
+          }
+          setSessionLoading(sessionId, false);
+        })();
+      }
+    }
+  }, [enabled]);
+}

--- a/src/services/tauri/git.ts
+++ b/src/services/tauri/git.ts
@@ -66,19 +66,6 @@ export async function gitBranchInfo(cwd: string) {
   return await postJson<GitBranchInfoResponse>('/api/git/branch-info', { cwd });
 }
 
-// Returns true iff `cwd` is a git working tree. Used to gate setCwd in
-// session-open handlers so non-project sessions (e.g. claude launched from
-// $HOME) don't trip the git-status pollers in useGitWatch consumers.
-export async function isGitRepo(cwd: string): Promise<boolean> {
-  if (!cwd) return false;
-  try {
-    await gitBranchInfo(cwd);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 export async function gitListBranches(cwd: string) {
   if (isDesktopTauri()) {
     return await invokeTauri<GitBranchListResponse>('git_list_branches', { cwd });

--- a/src/services/tauri/git.ts
+++ b/src/services/tauri/git.ts
@@ -66,6 +66,19 @@ export async function gitBranchInfo(cwd: string) {
   return await postJson<GitBranchInfoResponse>('/api/git/branch-info', { cwd });
 }
 
+// Returns true iff `cwd` is a git working tree. Used to gate setCwd in
+// session-open handlers so non-project sessions (e.g. claude launched from
+// $HOME) don't trip the git-status pollers in useGitWatch consumers.
+export async function isGitRepo(cwd: string): Promise<boolean> {
+  if (!cwd) return false;
+  try {
+    await gitBranchInfo(cwd);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function gitListBranches(cwd: string) {
   if (isDesktopTauri()) {
     return await invokeTauri<GitBranchListResponse>('git_list_branches', { cwd });


### PR DESCRIPTION
## Summary

Two related quality-of-life improvements for browsing and resuming sessions, especially in web/headless mode.

**1. URL-param deep-link hook** (`useUrlParamThread`)

Lets external launchers open Codexia straight to a specific Codex thread or Claude Code session via a plain URL — no Tauri deep-link plugin involved, so it works in browser tabs:

```
?agent=codex&thread=<id>&cwd=<path>      open Codex thread
?agent=cc&session=<id>&cwd=<path>        open Claude Code session
?addProject=<path>&addProject=<path>...  bulk-add projects to workspace
```

On first mount the hook reads the params, dispatches the same store updates a sidebar row click does (setCwd, setSelectedAgent, addAgentCard, setView('agent'), codexService.setCurrentThread for codex, JSONL replay for cc), and strips the params via `history.replaceState` so refresh doesn't re-fire. Gated on `codexReady` so it doesn't race the codex backend.

The bulk `addProject` mode is independent — it works alone (just register projects) or alongside agent navigation.

**2. Session-manager dialog: clickable rows + History icon**

The session-manager dialog already loads a flat, searchable, sortable list of every CC session and Codex thread — but row clicks did nothing; only the per-row trash button worked. This wires up row click (and keyboard Enter/Space) to open the session in the agent view, auto-close the dialog, and stops propagation on the checkbox / delete button so they don't trigger the open handler.

Also swaps the sidebar trigger icon from `Trash2` to `History` — the dialog is now a browse-and-manage view, not delete-only.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run build` clean
- [ ] Open a session-manager dialog, click any row → that session opens in the agent view, dialog closes
- [ ] Per-row delete button still works without opening the session
- [ ] Bulk-select via checkboxes still works
- [ ] Visit `?agent=codex&thread=<real-id>&cwd=<path>` in web mode → thread loads and resumes
- [ ] Visit `?addProject=/path/a&addProject=/path/b` → projects appear in workspace switcher
- [ ] Combined params work
- [ ] Sidebar history icon shows up in place of trash icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)