### PR TITLE
feat(settings): sync activeSidebarTab across devices via settings.json

### DIFF
--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -14,6 +14,7 @@ import { useWorkspaceStore } from '@/stores/useWorkspaceStore';
 import { useSettingsStore } from '@/stores/settings/useSettingsStore';
 import { useThemeStore } from '@/stores/settings/useThemeStore';
 import { useLocaleStore } from '@/stores/settings/useLocaleStore';
+import { useLayoutStore } from '@/stores/settings/useLayoutStore';
 import { useConfigStore } from '@/stores/codex/useConfigStore';
 
 const SETTINGS_FILE = '/.codexia/settings.json';
@@ -33,6 +34,10 @@ type WorkspaceData = {
 type ThemeData = {
   theme: string;
   accent: string;
+};
+
+type LayoutData = {
+  activeSidebarTab: string;
 };
 
 type AppData = {
@@ -76,6 +81,7 @@ interface SettingsFile {
   version: number;
   workspace?: Partial<WorkspaceData>;
   theme?: Partial<ThemeData>;
+  layout?: Partial<LayoutData>;
   locale?: { locale?: string };
   app?: Partial<AppData>;
   codexConfig?: Partial<CodexConfigData>;
@@ -128,6 +134,10 @@ export async function loadSettings(): Promise<void> {
     });
   }
 
+  if (data.layout?.activeSidebarTab !== undefined) {
+    useLayoutStore.setState({ activeSidebarTab: data.layout.activeSidebarTab as never });
+  }
+
   if (data.locale?.locale !== undefined) {
     useLocaleStore.setState({ locale: data.locale.locale as never });
   }
@@ -146,6 +156,7 @@ export async function loadSettings(): Promise<void> {
 function snapshot(): SettingsFile {
   const ws = useWorkspaceStore.getState();
   const theme = useThemeStore.getState();
+  const layout = useLayoutStore.getState();
   const locale = useLocaleStore.getState();
   const app = useSettingsStore.getState();
   const config = useConfigStore.getState();
@@ -163,6 +174,9 @@ function snapshot(): SettingsFile {
     theme: {
       theme: theme.theme,
       accent: theme.accent,
+    },
+    layout: {
+      activeSidebarTab: layout.activeSidebarTab,
     },
     locale: {
       locale: locale.locale,
@@ -229,6 +243,7 @@ export function initSettingsSync(): () => void {
   const unsubs = [
     useWorkspaceStore.subscribe(scheduleWrite),
     useThemeStore.subscribe(scheduleWrite),
+    useLayoutStore.subscribe(scheduleWrite),
     useLocaleStore.subscribe(scheduleWrite),
     useSettingsStore.subscribe(scheduleWrite),
     useConfigStore.subscribe(scheduleWrite),


### PR DESCRIPTION
## Summary

Tiny patch — `useLayoutStore.activeSidebarTab` is the one piece of "which agent am I looking at" state that wasn't already syncing across devices in web mode. It still uses its own `persist(localStorage)` middleware, so phone and laptop have independent agent tabs even though projects, selectedAgent, historyProjects, cwd, theme, locale, etc. all flow through `~/.codexia/settings.json` already (via `src/lib/settings.ts`).

This plumbs `activeSidebarTab` through the same snapshot/hydrate mechanism so the agent tab follows the user across devices on next load.

## What changes

- `LayoutData` type alongside `WorkspaceData` / `ThemeData`
- `layout?: Partial<LayoutData>` in `SettingsFile`
- Hydrate `useLayoutStore.activeSidebarTab` from `data.layout` in `loadSettings()`
- Include it in `snapshot()`
- `useLayoutStore.subscribe(scheduleWrite)` in `initSettingsSync()`

15-line diff in `src/lib/settings.ts`. Other `useLayoutStore` fields (sidebar open/closed, panel sizes, view, terminal open, diff word wrap) stay per-device-only via the existing `layout-storage` localStorage — only the agent tab is intentionally synced.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run build` clean
- [ ] Web mode: pick "Codex" tab on device A → reload device B → device B opens with Codex tab active
- [ ] Same in reverse with "CC" tab
- [ ] Other layout state (sidebar open/closed, right panel size) stays independent per device

🤖 Generated with [Claude Code](https://claude.com/claude-code)