### PR TITLE
feat: review-first session opens (gate agent spawn behind explicit Resume button)

### DIFF
--- a/src/components/cc/CCView.tsx
+++ b/src/components/cc/CCView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useCCSessionListener, useCCPermissionListener } from './hooks';
 
 import { useCCStore } from '@/stores/cc';
@@ -11,6 +11,7 @@ import { CCMessage } from '@/components/cc/messages';
 import { PermissionRequestCard } from '@/components/cc/messages/PermissionRequestCard';
 import { Composer } from '@/components/cc/composer/Composer';
 import { CCScrollControls } from '@/components/cc/CCScrollControls';
+import { Button } from '@/components/ui/button';
 import { buildMessageGroups, CCExploredMessageGroup } from './messages/group';
 import { buildInlineErrorsMap } from './messages/inlineErrors';
 import type { PermissionRequestMessage } from './types/messages';
@@ -67,28 +68,21 @@ export default function CCView({ sessionId, hideComposer = false, disableListene
     setLoading(false);
   }, [cwd, activeSessionId, clearMessages, setConnected, setLoading, isEmbedded]);
 
-  // Auto-resume when entering full-screen for a session not yet active (standalone only).
+  // Load JSONL history for the active session (always, independent of resume).
+  // Review-first: spawning the agent is gated behind an explicit Resume button
+  // (rendered below) so peeking at history doesn't pay the agent-spawn cost.
   useEffect(() => {
     if (isEmbedded) return;
-    if (!activeSessionId || activeSessionIds.includes(activeSessionId) || !cwd) return;
+    if (!activeSessionId || activeSessionIds.includes(activeSessionId)) return;
     const sid = activeSessionId;
     void (async () => {
       const filePath = await ccGetSessionFilePath(sid);
-      if (filePath) {
-        const lines = await readTextFileLines(filePath);
-        for (const msg of parseSessionJsonl(lines, sid)) {
-          addMessageToSession(sid, msg);
-        }
-        setSessionLoading(sid, false);
+      if (!filePath) return;
+      const lines = await readTextFileLines(filePath);
+      for (const msg of parseSessionJsonl(lines, sid)) {
+        addMessageToSession(sid, msg);
       }
-      await ccResumeSession(sid, {
-        cwd,
-        permissionMode: options.permissionMode,
-        resume: sid,
-        continueConversation: true,
-        ...(options.model ? { model: options.model } : {}),
-      });
-      addActiveSessionId(sid);
+      setSessionLoading(sid, false);
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeSessionId, isEmbedded]);
@@ -203,7 +197,66 @@ export default function CCView({ sessionId, hideComposer = false, disableListene
           onResolve={handleResolvePermission}
         />
       )}
-      {!isEmbedded && !hideComposer && pendingPermissionIdx === -1 && <Composer />}
+      {!isEmbedded && !hideComposer && pendingPermissionIdx === -1 && (
+        activeSessionId && !activeSessionIds.includes(activeSessionId) ? (
+          <ResumeSessionButton
+            sessionId={activeSessionId}
+            cwd={cwd}
+            permissionMode={options.permissionMode}
+            model={options.model}
+            onResumed={() => addActiveSessionId(activeSessionId)}
+          />
+        ) : (
+          <Composer />
+        )
+      )}
+    </div>
+  );
+}
+
+function ResumeSessionButton({
+  sessionId,
+  cwd,
+  permissionMode,
+  model,
+  onResumed,
+}: {
+  sessionId: string;
+  cwd: string;
+  permissionMode?: string;
+  model?: string;
+  onResumed: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const onClick = async () => {
+    if (!cwd) {
+      console.warn('[ResumeSessionButton] no cwd set; pick a project first');
+      return;
+    }
+    setBusy(true);
+    try {
+      await ccResumeSession(sessionId, {
+        cwd,
+        permissionMode,
+        resume: sessionId,
+        continueConversation: true,
+        ...(model ? { model } : {}),
+      });
+      onResumed();
+    } catch (err) {
+      console.error('[ResumeSessionButton] ccResumeSession failed:', err);
+    } finally {
+      setBusy(false);
+    }
+  };
+  return (
+    <div className="flex items-center justify-between gap-3 p-4 m-2 rounded-lg border border-border bg-muted/40 text-sm">
+      <span className="text-muted-foreground">
+        {cwd ? 'Reviewing history. Resume to send messages.' : 'Pick a project to resume this session.'}
+      </span>
+      <Button onClick={onClick} disabled={busy || !cwd} size="sm">
+        {busy ? 'Resuming…' : 'Resume session'}
+      </Button>
     </div>
   );
 }

--- a/src/components/codex/ChatInterface.tsx
+++ b/src/components/codex/ChatInterface.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, type ReactNode } from 'react';
+import { useRef, useEffect, useState, type ReactNode } from 'react';
 import { useCodexStore } from '@/stores/codex';
 import { useIsProcessing } from '@/hooks/codex';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -9,10 +9,13 @@ import { Markdown } from '@/components/Markdown';
 import { Composer } from './Composer';
 import { CodexAuth } from './CodexAuth';
 import { useSettingsStore } from '@/stores/settings';
+import { codexService } from '@/services/codexService';
+import { Button } from '@/components/ui/button';
 
 export function ChatInterface({ hideComposer = false }: { hideComposer?: boolean } = {}) {
-  const { currentThreadId, events, hasAccount } = useCodexStore();
+  const { currentThreadId, events, hasAccount, activeThreadIds } = useCodexStore();
   const { taskDetail, showReasoning } = useSettingsStore();
+  const isLive = !!currentThreadId && activeThreadIds.includes(currentThreadId);
   const isProcessing = useIsProcessing();
   const bottomAnchorRef = useRef<HTMLDivElement>(null);
 
@@ -171,9 +174,37 @@ export function ChatInterface({ hideComposer = false }: { hideComposer?: boolean
       {/* Input Area */}
       {!hideComposer && (
         <div className="absolute bottom-0 left-0 right-0 px-2 sm:px-0 max-w-3xl mx-auto">
-          <Composer />
+          {currentThreadId && !isLive ? (
+            <ResumeThreadButton threadId={currentThreadId} />
+          ) : (
+            <Composer />
+          )}
         </div>
       )}
+    </div>
+  );
+}
+
+function ResumeThreadButton({ threadId }: { threadId: string }) {
+  const [busy, setBusy] = useState(false);
+  const onClick = async () => {
+    setBusy(true);
+    try {
+      await codexService.threadResume(threadId);
+    } catch (err) {
+      console.error('[ResumeThreadButton] threadResume failed:', err);
+    } finally {
+      setBusy(false);
+    }
+  };
+  return (
+    <div className="flex items-center justify-between gap-3 p-4 mb-2 rounded-lg border border-border bg-muted/40 text-sm">
+      <span className="text-muted-foreground">
+        Reviewing history. Resume to send messages.
+      </span>
+      <Button onClick={onClick} disabled={busy} size="sm">
+        {busy ? 'Resuming…' : 'Resume session'}
+      </Button>
     </div>
   );
 }

--- a/src/services/codexService.ts
+++ b/src/services/codexService.ts
@@ -174,9 +174,15 @@ export const codexService = {
       throw error;
     }
   },
-  async setCurrentThread(threadId: string | null, options?: { resume?: boolean }) {
+  async setCurrentThread(threadId: string | null, _options?: { resume?: boolean }) {
+    // Review-first behavior: setting the current thread no longer auto-resumes
+    // the agent process. Live threads (already in activeThreadIds with cached
+    // events) just switch view + derive activeTurnId. Dormant threads switch
+    // view but stay disconnected — ChatInterface renders an explicit Resume
+    // button to spawn the agent on demand. Lets users peek at history without
+    // paying the agent-spawn cost. The `options.resume` parameter is preserved
+    // for API compat but no longer triggers a resume.
     const set = useCodexStore.setState;
-    const shouldResume = options?.resume ?? true;
     try {
       if (!threadId) {
         set((state) => ({
@@ -187,29 +193,11 @@ export const codexService = {
         return;
       }
 
-      if (!shouldResume) {
-        set((state) => ({
-          currentThreadId: threadId,
-          currentTurnId: null,
-          inputFocusTrigger: state.inputFocusTrigger + 1,
-        }));
-        return;
-      }
-
       const { activeThreadIds, events } = useCodexStore.getState();
 
-      if (!activeThreadIds.includes(threadId) || !events[threadId]) {
-        // Optimistically set currentThreadId before the async resume so ChatInterface
-        // renders with the correct (empty) event list instead of a stale thread's state.
-        set((state) => ({
-          currentThreadId: threadId,
-          currentTurnId: null,
-          inputFocusTrigger: state.inputFocusTrigger + 1,
-        }));
-        await codexService.threadResume(threadId);
-      } else {
-        // Derive the active turn ID from the thread's live events so the Stop button
-        // works correctly when the thread is still processing.
+      if (activeThreadIds.includes(threadId) && events[threadId]) {
+        // Live thread — derive the active turn id from streaming events so the
+        // Stop button works correctly when a turn is in progress.
         const threadEvents = events[threadId] ?? [];
         let activeTurnId: string | null = null;
         for (let i = threadEvents.length - 1; i >= 0; i--) {
@@ -225,6 +213,13 @@ export const codexService = {
         set((state) => ({
           currentThreadId: threadId,
           currentTurnId: activeTurnId,
+          inputFocusTrigger: state.inputFocusTrigger + 1,
+        }));
+      } else {
+        // Dormant — view-only. User clicks Resume in ChatInterface to connect.
+        set((state) => ({
+          currentThreadId: threadId,
+          currentTurnId: null,
           inputFocusTrigger: state.inputFocusTrigger + 1,
         }));
       }


### PR DESCRIPTION
## Summary

Opening a session in codexia currently spawns a full agent process (Codex `app-server` thread or `claude-agent-sdk` connection) on click — even if the user just wants to peek at the transcript. With users routinely flipping through old sessions to find one (especially with the new session-manager dialog in #60, but the same is true for sidebar row clicks), this adds up to meaningful memory pressure for a workflow that doesn't need a live agent.

This PR drops the implicit auto-resume. Opening a session loads its on-disk history (JSONL for CC, cached events for Codex) and renders the transcript — but the composer is swapped for a "Resume session" card. Click that to actually spawn the agent.

## Behavior

- **Live sessions** (in `activeSessionIds` / `activeThreadIds`): no change. Composer renders, you can send messages immediately, existing live context preserved.
- **Dormant sessions**: composer is replaced by a small Resume card. One click → `ccResumeSession` / `codexService.threadResume` fires → agent connects → composer reappears.

Affects every entry point uniformly: sidebar row click, history-icon session-manager rows (#60), URL deep-link (#60), grid card click. Live sessions short-circuit and behave exactly as before — no regression for users currently in a session.

## Why

> "every time a non-live session is opened, you should review first"
> "that will give me better control over memory usage and not trigger a ton of memory usage just from peeking into a session history"

— from a user moving through their session history quickly, where 5+ sessions in a row would otherwise spin up 5+ agent processes.

## Implementation

- **`src/services/codexService.ts`** — `setCurrentThread` no longer awaits `threadResume`. It just sets `currentThreadId` (and derives `activeTurnId` for live threads from streaming events). The `options.resume` parameter is preserved for API compat but is now a no-op. The Resume button calls `codexService.threadResume()` directly.
- **`src/components/codex/ChatInterface.tsx`** — renders a small `ResumeThreadButton` in place of `Composer` when `currentThreadId` is set but not in `activeThreadIds`.
- **`src/components/cc/CCView.tsx`** — the previous auto-resume `useEffect` is split: JSONL load stays (so review works without the agent), the `ccResumeSession` call is removed. `Composer` is swapped for `ResumeSessionButton` when `activeSessionId` isn't in `activeSessionIds`. The button replicates the original resume options (`cwd`, `permissionMode`, `model`, `resume: sid`, `continueConversation`).

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run build` clean
- [ ] Click a non-live session in the sidebar → transcript loads, composer is replaced by "Resume session" card
- [ ] Click Resume → agent spawns, composer appears, sending works
- [ ] Click a live session → composer renders directly (no Resume card)
- [ ] Open the history-icon dialog (#60) → click any non-live row → review mode
- [ ] New session creation (`handleNewSession` / `handleNewThread`) still works — these call `ccResumeSession`/`threadResume` directly so they're unaffected
- [ ] Memory: open 3-4 dormant sessions in succession → no extra agent processes spawn (verifiable via `ps`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)