### PR TITLE
Add Codex Skin Pack Installer to recommended tools

### DIFF
--- a/src/assets/recommend.json
+++ b/src/assets/recommend.json
@@ -5,6 +5,12 @@
             "description": "Use Garry Tan's exact Claude Code setup: 23 opinionated tools that serve as CEO, Designer, Eng Manager, Release Manager, Doc Engineer, and QA",
             "url": "https://github.com/garrytan/gstack",
             "setup": "git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup"
+        },
+        {
+            "name": "Codex Skin Pack Installer",
+            "description": "Install verified public-safe Codex desktop skin packs from a Codex plugin and Skill, with theme validation and restore guidance.",
+            "url": "https://github.com/ChannelerH/codex-skin-packs",
+            "setup": "codex plugin marketplace add ChannelerH/codex-skin-packs --ref main --sparse .agents/plugins --sparse plugins/codex-skin-pack-installer\ncodex plugin add codex-skin-pack-installer@codex-skin-packs"
         }
     ]
 }


### PR DESCRIPTION
Adds Codex Skin Pack Installer to the recommended tools list so Codexia users can copy the setup command directly from the app.

Project link: https://github.com/ChannelerH/codex-skin-packs

Why it fits:
- It is a Codex plugin and standalone Skill for installing verified public-safe Codex desktop skin packs.
- The setup command uses the Codex plugin marketplace flow and then installs `codex-skin-pack-installer@codex-skin-packs`.
- The plugin stages release downloads, validates `theme.json` / `background.png`, and keeps restore guidance visible.

Validation:
- `python3 -m json.tool src/assets/recommend.json`
- Verified the setup command in an isolated `HOME`.
- `bun run build`
