### PR TITLE
feat: add MiniMax provider with global and CN endpoints

### DIFF
--- a/crates/codex/src/llms.json
+++ b/crates/codex/src/llms.json
@@ -72,6 +72,42 @@
       "signup_url": "",
       "env_key": "CUSTOM_API_KEY",
       "auto_discover": true
+    },
+    {
+      "model_provider": "minimax",
+      "base_url": "https://api.minimax.io/v1",
+      "api_key_url": "https://platform.minimax.io",
+      "signup_url": "https://platform.minimax.io",
+      "env_key": "MINIMAX_API_KEY",
+      "auto_discover": false,
+      "models": [
+        {
+          "id": "MiniMax-M3",
+          "context_length": 1000000
+        },
+        {
+          "id": "MiniMax-M2.7",
+          "context_length": 204800
+        }
+      ]
+    },
+    {
+      "model_provider": "minimax_cn",
+      "base_url": "https://api.minimaxi.com/v1",
+      "api_key_url": "https://platform.minimaxi.com",
+      "signup_url": "https://platform.minimaxi.com",
+      "env_key": "MINIMAX_API_KEY",
+      "auto_discover": false,
+      "models": [
+        {
+          "id": "MiniMax-M3",
+          "context_length": 1000000
+        },
+        {
+          "id": "MiniMax-M2.7",
+          "context_length": 204800
+        }
+      ]
     }
   ]
 }

--- a/src/components/codex/constants.tsx
+++ b/src/components/codex/constants.tsx
@@ -1,1 +1,10 @@
-export const modelProviders = ['openai', 'atlascloud', 'ollama', 'openrouter', 'nvidia', 'custom'];
+export const modelProviders = [
+  'openai',
+  'atlascloud',
+  'ollama',
+  'openrouter',
+  'nvidia',
+  'custom',
+  'minimax',
+  'minimax_cn',
+];


### PR DESCRIPTION
Reason: Add MiniMax as a supported LLM provider with MiniMax-M3 and MiniMax-M2.7 models.

Adds the MiniMax provider to the bundled `llms.json` provider registry, covering both the documented global (`https://api.minimax.io/v1`) and China (`https://api.minimaxi.com/v1`) OpenAI-compatible regional endpoints. Each entry registers the current text models `MiniMax-M3` (1,000,000-token context) and `MiniMax-M2.7` (204,800-token context) as static models, matching the existing registry schema used by `atlascloud`/`openrouter`/`nvidia`.

Also adds the `minimax` and `minimax_cn` provider names to the frontend `modelProviders` list in `src/components/codex/constants.tsx` so the new providers appear in the Codex model selector.

Checks run:
- `bun run typecheck` (`tsc --noEmit`) — passed
- `biome check` on the changed TypeScript file — passed
- `jq` validation of `crates/codex/src/llms.json` — passed
