### PR TITLE
feat: LoopX should-run pre-flight for automation scheduler

### DIFF
--- a/crates/cc/src/automation/execution.rs
+++ b/crates/cc/src/automation/execution.rs
@@ -278,6 +278,38 @@ pub(super) async fn execute_task(
     }
 }
 
+/// Pulls the `--goal-id <value>` flag out of an `AutomationTask.prompt` string. The task
+/// model has no dedicated `goal_id` field — the goal-id lives only inside the prompt text
+/// a human (or Codexia's UI) fills in, per the approved prompt template. Returns `None`
+/// for any prompt that isn't a `loopx-tick`-shaped instruction, or where the flag is
+/// malformed/missing its value — both cases are treated identically by the caller: no
+/// pre-flight opinion, proceed as if this feature didn't exist.
+fn extract_goal_id(prompt: &str) -> Option<String> {
+    let flag = "--goal-id";
+    let start = prompt.find(flag)? + flag.len();
+    prompt[start..]
+        .split_whitespace()
+        .next()
+        .map(|value| value.trim_matches('`').to_string())
+        .filter(|value| !value.is_empty() && !value.starts_with("--"))
+}
+
+/// Interprets the result of shelling out to `loopx --format json quota should-run`.
+/// Returns `true` only when the process exited 0, produced valid JSON, and that JSON has
+/// `"should_run": false` (a real boolean `false`, not a string or other type) — the one
+/// case approved as a real reason to skip launching a session. Every other outcome
+/// returns `false`: an infra error here must never silently skip a wake, since an
+/// unnecessary session is cheap and reversible while a silently-skipped wake is not.
+fn should_skip_from_output(exit_status: i32, stdout: &str) -> bool {
+    if exit_status != 0 {
+        return false;
+    }
+    match serde_json::from_str::<Value>(stdout) {
+        Ok(json) => json.get("should_run").and_then(Value::as_bool) == Some(false),
+        Err(_) => false,
+    }
+}
+
 #[cfg(test)]
 mod preflight_tests {
     use super::*;

--- a/crates/cc/src/automation/execution.rs
+++ b/crates/cc/src/automation/execution.rs
@@ -284,6 +284,12 @@ mod preflight_tests {
 
     #[test]
     fn extract_goal_id_finds_the_flag_value() {
+        let prompt = "Run alphalayer loopx-tick myflows.digest:flow --goal-id nightly-digest in this directory via the shell. Report its one-line output, then stop.";
+        assert_eq!(extract_goal_id(prompt), Some("nightly-digest".to_string()));
+    }
+
+    #[test]
+    fn extract_goal_id_strips_trailing_backtick() {
         let prompt = "Run `alphalayer loopx-tick myflows.digest:flow --goal-id nightly-digest` in this directory via the shell. Report its one-line output, then stop.";
         assert_eq!(extract_goal_id(prompt), Some("nightly-digest".to_string()));
     }
@@ -301,35 +307,55 @@ mod preflight_tests {
     }
 
     #[test]
-    fn should_skip_session_is_false_when_should_run_reports_true() {
+    fn extract_goal_id_returns_none_when_flag_is_followed_by_another_flag() {
+        let prompt = "Run `alphalayer loopx-tick myflows.digest:flow --goal-id --other-flag value` in this directory via the shell.";
+        assert_eq!(extract_goal_id(prompt), None);
+    }
+
+    #[test]
+    fn should_skip_from_output_is_false_when_should_run_reports_true() {
         // "loopx" prints `{"should_run": true}` — proceed with the session.
-        let outcome = interpret_should_run_output(0, r#"{"should_run": true}"#);
+        let outcome = should_skip_from_output(0, r#"{"should_run": true}"#);
         assert!(!outcome);
     }
 
     #[test]
-    fn should_skip_session_is_true_only_on_a_clean_false() {
-        let outcome = interpret_should_run_output(0, r#"{"should_run": false, "reason": "quota exhausted"}"#);
+    fn should_skip_from_output_is_true_only_on_a_clean_false() {
+        let outcome = should_skip_from_output(0, r#"{"should_run": false, "reason": "quota exhausted"}"#);
         assert!(outcome);
     }
 
     #[test]
-    fn should_skip_session_is_false_on_nonzero_exit() {
+    fn should_skip_from_output_is_false_on_nonzero_exit() {
         // Fail open: an infra error must never silently skip a wake.
-        let outcome = interpret_should_run_output(1, "");
+        let outcome = should_skip_from_output(1, "");
         assert!(!outcome);
     }
 
     #[test]
-    fn should_skip_session_is_false_on_unparseable_json() {
-        let outcome = interpret_should_run_output(0, "not json");
+    fn should_skip_from_output_is_false_on_nonzero_exit_even_with_valid_should_run_false_json() {
+        // Exit-code failure must override an otherwise-parseable negative signal.
+        let outcome = should_skip_from_output(1, r#"{"should_run": false, "reason": "quota exhausted"}"#);
         assert!(!outcome);
     }
 
     #[test]
-    fn should_skip_session_is_false_when_should_run_field_missing() {
+    fn should_skip_from_output_is_false_on_unparseable_json() {
+        let outcome = should_skip_from_output(0, "not json");
+        assert!(!outcome);
+    }
+
+    #[test]
+    fn should_skip_from_output_is_false_when_should_run_field_missing() {
         // Missing field defaults to "runnable" (proceed) rather than assuming skip.
-        let outcome = interpret_should_run_output(0, r#"{"reason": "no field here"}"#);
+        let outcome = should_skip_from_output(0, r#"{"reason": "no field here"}"#);
+        assert!(!outcome);
+    }
+
+    #[test]
+    fn should_skip_from_output_is_false_when_should_run_is_wrong_type() {
+        // Fail open on schema mismatch, not just on totally-unparseable JSON.
+        let outcome = should_skip_from_output(0, r#"{"should_run": "true"}"#);
         assert!(!outcome);
     }
 }

--- a/crates/cc/src/automation/execution.rs
+++ b/crates/cc/src/automation/execution.rs
@@ -285,10 +285,9 @@ pub(super) async fn execute_task(
 /// malformed/missing its value — both cases are treated identically by the caller: no
 /// pre-flight opinion, proceed as if this feature didn't exist.
 fn extract_goal_id(prompt: &str) -> Option<String> {
-    let flag = "--goal-id";
-    let start = prompt.find(flag)? + flag.len();
-    prompt[start..]
-        .split_whitespace()
+    let mut tokens = prompt.split_whitespace();
+    tokens.find(|token| *token == "--goal-id")?;
+    tokens
         .next()
         .map(|value| value.trim_matches('`').to_string())
         .filter(|value| !value.is_empty() && !value.starts_with("--"))
@@ -341,6 +340,12 @@ mod preflight_tests {
     #[test]
     fn extract_goal_id_returns_none_when_flag_is_followed_by_another_flag() {
         let prompt = "Run `alphalayer loopx-tick myflows.digest:flow --goal-id --other-flag value` in this directory via the shell.";
+        assert_eq!(extract_goal_id(prompt), None);
+    }
+
+    #[test]
+    fn extract_goal_id_does_not_match_a_flag_that_merely_contains_goal_id_as_a_substring() {
+        let prompt = "Run task --goal-id-format short in this directory.";
         assert_eq!(extract_goal_id(prompt), None);
     }
 

--- a/crates/cc/src/automation/execution.rs
+++ b/crates/cc/src/automation/execution.rs
@@ -239,6 +239,17 @@ pub(super) async fn execute_task(
     cc_state: CCState,
     event_sink: Arc<dyn EventSink>,
 ) {
+    if let Some(goal_id) = extract_goal_id(&task.prompt) {
+        if should_skip_session(&goal_id) {
+            log::info!(
+                "automation '{}' skipped — LoopX goal '{}' reported not runnable",
+                task.id,
+                goal_id
+            );
+            return;
+        }
+    }
+
     if task.agent == "cc" {
         if let Err(err) = run_task_with_cc(task.clone(), cc_state).await {
             log::error!("automation '{}' execution failed: {}", task.id, err);
@@ -305,6 +316,23 @@ fn should_skip_from_output(exit_status: i32, stdout: &str) -> bool {
     }
     match serde_json::from_str::<Value>(stdout) {
         Ok(json) => json.get("should_run").and_then(Value::as_bool) == Some(false),
+        Err(_) => false,
+    }
+}
+
+/// Shells out to `loopx --format json quota should-run --goal-id <goal_id>`. Any failure
+/// to even launch the process (binary not on PATH, spawn error) is treated the same as a
+/// nonzero exit by `should_skip_from_output` — fail open, proceed with the session.
+fn should_skip_session(goal_id: &str) -> bool {
+    let output = std::process::Command::new("loopx")
+        .args(["--format", "json", "quota", "should-run", "--goal-id", goal_id])
+        .output();
+
+    match output {
+        Ok(output) => should_skip_from_output(
+            output.status.code().unwrap_or(-1),
+            &String::from_utf8_lossy(&output.stdout),
+        ),
         Err(_) => false,
     }
 }

--- a/crates/cc/src/automation/execution.rs
+++ b/crates/cc/src/automation/execution.rs
@@ -246,6 +246,10 @@ pub(super) async fn execute_task(
                 task.id,
                 goal_id
             );
+            event_sink.emit(
+                "automation:run/skipped",
+                json!({ "taskId": task.id, "goalId": goal_id, "reason": "not_runnable" }),
+            );
             return;
         }
     }

--- a/crates/cc/src/automation/execution.rs
+++ b/crates/cc/src/automation/execution.rs
@@ -277,3 +277,59 @@ pub(super) async fn execute_task(
         log::info!("automation '{}' executed", task.id);
     }
 }
+
+#[cfg(test)]
+mod preflight_tests {
+    use super::*;
+
+    #[test]
+    fn extract_goal_id_finds_the_flag_value() {
+        let prompt = "Run `alphalayer loopx-tick myflows.digest:flow --goal-id nightly-digest` in this directory via the shell. Report its one-line output, then stop.";
+        assert_eq!(extract_goal_id(prompt), Some("nightly-digest".to_string()));
+    }
+
+    #[test]
+    fn extract_goal_id_returns_none_when_absent() {
+        let prompt = "Summarize the open PRs in this repo.";
+        assert_eq!(extract_goal_id(prompt), None);
+    }
+
+    #[test]
+    fn extract_goal_id_returns_none_for_malformed_flag() {
+        let prompt = "Run `alphalayer loopx-tick myflows.digest:flow --goal-id` with nothing after it.";
+        assert_eq!(extract_goal_id(prompt), None);
+    }
+
+    #[test]
+    fn should_skip_session_is_false_when_should_run_reports_true() {
+        // "loopx" prints `{"should_run": true}` — proceed with the session.
+        let outcome = interpret_should_run_output(0, r#"{"should_run": true}"#);
+        assert!(!outcome);
+    }
+
+    #[test]
+    fn should_skip_session_is_true_only_on_a_clean_false() {
+        let outcome = interpret_should_run_output(0, r#"{"should_run": false, "reason": "quota exhausted"}"#);
+        assert!(outcome);
+    }
+
+    #[test]
+    fn should_skip_session_is_false_on_nonzero_exit() {
+        // Fail open: an infra error must never silently skip a wake.
+        let outcome = interpret_should_run_output(1, "");
+        assert!(!outcome);
+    }
+
+    #[test]
+    fn should_skip_session_is_false_on_unparseable_json() {
+        let outcome = interpret_should_run_output(0, "not json");
+        assert!(!outcome);
+    }
+
+    #[test]
+    fn should_skip_session_is_false_when_should_run_field_missing() {
+        // Missing field defaults to "runnable" (proceed) rather than assuming skip.
+        let outcome = interpret_should_run_output(0, r#"{"reason": "no field here"}"#);
+        assert!(!outcome);
+    }
+}

--- a/crates/cc/src/automation/execution.rs
+++ b/crates/cc/src/automation/execution.rs
@@ -240,7 +240,23 @@ pub(super) async fn execute_task(
     event_sink: Arc<dyn EventSink>,
 ) {
     if let Some(goal_id) = extract_goal_id(&task.prompt) {
-        if should_skip_session(&goal_id) {
+        // `should_skip_session` blocks on a subprocess, so it must not run inline on this
+        // async task's Tokio worker thread — that thread is shared with other scheduled
+        // automations (see `runtime.rs` / `service.rs`), and a hung `loopx` process would
+        // otherwise stall unrelated ticks indefinitely. `spawn_blocking` moves the call to
+        // the blocking pool; the surrounding `timeout` bounds how long we'll wait for it.
+        // A join error or a timeout is treated the same as every other infra failure here:
+        // fail open, proceed with the session.
+        let goal_id_for_check = goal_id.clone();
+        let skip_result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            tokio::task::spawn_blocking(move || should_skip_session(&goal_id_for_check)),
+        )
+        .await;
+
+        let should_skip = matches!(skip_result, Ok(Ok(true)));
+
+        if should_skip {
             log::info!(
                 "automation '{}' skipped — LoopX goal '{}' reported not runnable",
                 task.id,
@@ -324,12 +340,27 @@ fn should_skip_from_output(exit_status: i32, stdout: &str) -> bool {
     }
 }
 
-/// Shells out to `loopx --format json quota should-run --goal-id <goal_id>`. Any failure
-/// to even launch the process (binary not on PATH, spawn error) is treated the same as a
-/// nonzero exit by `should_skip_from_output` — fail open, proceed with the session.
+/// Shells out to `loopx --format json quota should-run --goal-id <goal_id> --agent-id
+/// codexia`. This is a *blocking* call (`std::process::Command::output`) — callers on the
+/// async runtime must run it via `tokio::task::spawn_blocking` with a timeout, since a
+/// hung `loopx` process must never tie up a shared Tokio worker thread. `--agent-id` is
+/// sent to match the sibling Python client's `_should_run_args` (`alphalayer/loopx.py`),
+/// which always sends both flags; `"codexia"` identifies this caller the way the Python
+/// client's default `"alphalayer"` identifies its own. Any failure to even launch the
+/// process (binary not on PATH, spawn error) is treated the same as a nonzero exit by
+/// `should_skip_from_output` — fail open, proceed with the session.
 fn should_skip_session(goal_id: &str) -> bool {
     let output = std::process::Command::new("loopx")
-        .args(["--format", "json", "quota", "should-run", "--goal-id", goal_id])
+        .args([
+            "--format",
+            "json",
+            "quota",
+            "should-run",
+            "--goal-id",
+            goal_id,
+            "--agent-id",
+            "codexia",
+        ])
         .output();
 
     match output {


### PR DESCRIPTION
## Summary

Adds an optional pre-flight check to `execute_task` (the automation scheduler's task
entry point): if a task's prompt names a LoopX goal (`--goal-id <id>`, per the
[Codexia↔LoopX integration design](https://github.com/connorodea/alphalayer/blob/main/docs/superpowers/specs/2026-08-06-codexia-loopx-integration-design.md)),
this shells out to `loopx quota should-run` before launching a Codex/Claude Code
session, and skips the session entirely if LoopX reports the goal isn't runnable
right now (e.g. quota exhausted). Tasks with no `--goal-id` in their prompt are
completely unaffected — this only activates for AlphaLayer/LoopX-driven automations.

**Fails open by design:** any infra error in the pre-flight itself (loopx not
installed, malformed output, timeout, a hung process) is treated identically to
"proceed" — an unnecessary session is cheap and reversible, while a silently-skipped
wake would be a much harder failure to notice from this app's UI.

## Changes

- `extract_goal_id` — pulls `--goal-id <value>` out of a task's prompt (no dedicated
  field exists on `AutomationTask` for this; the goal-id lives only in the prompt
  text per the approved prompt-template design).
- `should_skip_from_output` / `should_skip_session` — pure interpreter + I/O wrapper
  around `loopx --format json quota should-run --goal-id <id> --agent-id codexia`.
- Wired into `execute_task`, run via `tokio::task::spawn_blocking` with a 5s
  `tokio::time::timeout` — the blocking subprocess call must not run inline on the
  shared Tokio worker pool used by other scheduled automations.
- `automation:run/skipped` event emitted on skip (matches the existing
  `event_sink.emit` pattern used for the codex-unavailable skip and both
  `run_task_with_*` failure paths — no `automation_runs` DB row, consistent with
  those events not requiring a session/thread id that a skip never has).

## Known limitations (accepted, not fixed here)

- **The `loopx` CLI contract is unverified against a live install.** Both this Rust
  client and the sibling Python client in AlphaLayer are written against LoopX's
  documented contract, not a real binary — if the real CLI's flags/JSON shape differ,
  this pre-flight will always fail open (i.e. never actually skip anything) rather
  than error visibly. Flagged explicitly in the design spec's own open questions; a
  live end-to-end smoke test is deferred pending a real Codexia+LoopX+Flow target.
- **No test proves the composed skip path in `execute_task`.** `extract_goal_id` and
  `should_skip_from_output` are unit-tested in isolation (13 tests); `execute_task`
  itself is `async` and needs a live `CCState`, and `should_skip_session` isn't
  behind an injectable seam, so nothing currently mocks LoopX's two outcomes end to
  end. Accepted as out of scope for this PR — would need a larger refactor
  (injectable trait for the should-run check) to close.

## Test plan

- [x] `cargo test -p codexia-cc` — 17/17 passing (13 new `preflight_tests` + 4
      pre-existing `automation::schedule` tests)
- [x] `cargo check -p codexia-cc --tests` — clean
- [ ] Live smoke test against a real Codexia automation task + LoopX goal — deferred,
      see "Known limitations" above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xp6usr82yCYcQpTvix1pwZ