### PR TITLE
Add Parallel Search to Quick Add servers

### DIFF
--- a/src/features/mcp/DefaultMcpServers.tsx
+++ b/src/features/mcp/DefaultMcpServers.tsx
@@ -30,6 +30,15 @@ export function DefaultMcpServers({ servers, onServerAdded }: DefaultMcpServersP
         url: 'https://mcp.deepwiki.com/mcp',
       },
     },
+    {
+      name: 'parallel-search',
+      description:
+        'Search the web and fetch requested URLs with no account or API key. When you use its tools, your search objectives, search queries, and requested URLs are sent to Parallel.',
+      config: {
+        type: 'http' as const,
+        url: 'https://search.parallel.ai/mcp',
+      },
+    },
   ];
 
   const handleAddDefaultServer = async (defaultServer: (typeof defaultServers)[0]) => {


### PR DESCRIPTION
## Why

Adds Parallel Search as an optional Quick Add server for Codexia users who want web search and URL fetching. The default endpoint does not require an account or API key; users can review the [Parallel Search MCP documentation](https://docs.parallel.ai/integrations/mcp/search-mcp) for details.

## Changes

- Add one inert `parallel-search` card alongside the existing Quick Add servers, using Codexia's existing HTTP MCP configuration and `https://search.parallel.ai/mcp` endpoint.
- Keep installation explicitly opt-in: the server is configured only when a user clicks **Add**.
- Preserve every existing server, default, user configuration, and gateway authorization behavior.
- Disclose that user-provided search objectives, search queries, and requested URLs are sent to Parallel when its tools are explicitly used.

## Validation

- Focused source assertions for the server name, HTTP configuration, endpoint, anonymous-access wording, privacy disclosure, and placement alongside DeepWiki: passed.
- `git diff --check`: passed.
- Verified the patch changes only `src/features/mcp/DefaultMcpServers.tsx`.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.