### PR TITLE
Add bot mode functionality

### DIFF
--- a/crates/acp/src/agents.rs
+++ b/crates/acp/src/agents.rs
@@ -25,6 +25,13 @@ pub struct AcpAgentDef {
     /// Whether `command` resolves on PATH. Only filled in by `list_agents`.
     #[serde(default)]
     pub available: bool,
+    /// Whether the resolved launcher is the agent's own installed binary
+    /// rather than the `npx` download fallback. `available` alone says only
+    /// that *something* can be spawned: with Node present every npm-published
+    /// agent is "available", which is not what a caller asking "is this agent
+    /// installed?" means.
+    #[serde(default)]
+    pub local: bool,
 }
 
 /// One way to launch an agent. Presets list several, local binary first and
@@ -154,6 +161,7 @@ impl Preset {
             .find(|launcher| which::which(launcher.command).is_ok());
         let available = found.is_some();
         let launcher = found.unwrap_or_else(|| self.launchers.last().expect("preset launcher"));
+        let local = available && launcher.command != "npx";
 
         AcpAgentDef {
             id: self.id.to_string(),
@@ -166,6 +174,7 @@ impl Preset {
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect(),
             available,
+            local,
         }
     }
 }
@@ -217,6 +226,7 @@ fn user_agents() -> Vec<AcpAgentDef> {
                 id: entry.id.unwrap_or_else(|| slug(&name)),
                 name,
                 available: which::which(&entry.command).is_ok(),
+                local: which::which(&entry.command).is_ok(),
                 command: entry.command,
                 args: entry.args,
                 env: entry.env,
@@ -244,4 +254,77 @@ pub fn list_agents() -> Vec<AcpAgentDef> {
 
 pub fn find_preset(id: &str) -> Option<AcpAgentDef> {
     list_agents().into_iter().find(|a| a.id == id)
+}
+
+/// The npm package a preset would otherwise download on every run, read off
+/// its `npx` launcher so there is only one place naming a package. `None` for
+/// an agent that has no npm distribution — those can only be installed by hand.
+fn npm_package(id: &str) -> Option<&'static str> {
+    let preset = PRESETS.iter().find(|p| p.id == id)?;
+    let npx = preset.launchers.iter().find(|l| l.command == "npx")?;
+    let package = npx.args.iter().find(|a| !a.starts_with('-'))?;
+    Some(package)
+}
+
+/// Install a preset globally with npm, so it resolves on PATH from then on.
+///
+/// The `npx` fallback launcher means an agent can run without this, but only
+/// by re-downloading the package on every spawn — and only when Node is
+/// installed at all. This is the one-off that makes the agent local.
+pub fn install_preset(id: &str) -> Result<AcpAgentDef, String> {
+    let package = npm_package(id).ok_or_else(|| format!("{id} has no npm package to install"))?;
+    let npm = which::which("npm")
+        .map_err(|_| "npm was not found on PATH — install Node.js first.".to_string())?;
+
+    log::info!("acp: installing {id} via npm install -g {package}");
+    let output = std::process::Command::new(npm)
+        .args(["install", "-g", package])
+        .output()
+        .map_err(|e| format!("could not run npm: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let message = stderr.trim();
+        return Err(if message.is_empty() {
+            format!("npm install -g {package} failed")
+        } else {
+            message.to_string()
+        });
+    }
+
+    let def = find_preset(id).ok_or_else(|| format!("{id} is not a known agent"))?;
+    log::info!(
+        "acp: installed {id}: command={} local={} available={}",
+        def.command,
+        def.local,
+        def.available
+    );
+    Ok(def)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn npm_package_comes_from_the_npx_launcher() {
+        assert_eq!(npm_package("keke"), Some("@milisp/keke@latest"));
+        // No npx launcher, so nothing to install for us.
+        assert_eq!(npm_package("kiro"), None);
+        assert_eq!(npm_package("nope"), None);
+    }
+
+    #[test]
+    fn npx_fallback_is_not_a_local_install() {
+        let def = AcpAgentDef {
+            id: "keke".into(),
+            name: "Keke".into(),
+            command: "npx".into(),
+            args: vec![],
+            env: Default::default(),
+            available: true,
+            local: false,
+        };
+        assert!(def.available && !def.local);
+    }
 }

--- a/crates/acp/src/client.rs
+++ b/crates/acp/src/client.rs
@@ -25,6 +25,10 @@ pub struct AcpClient {
     pub agent_id: String,
     /// Display name of the agent, stored alongside persisted sessions.
     pub agent_name: String,
+    /// The bot this process was started for, when it was started from the Bot
+    /// tab. Every session it opens is tagged with it, which is what keeps a
+    /// bot's conversations out of the per-project session lists.
+    pub bot_id: Option<String>,
     /// Sessions opened on this connection, keyed by ACP session id. One agent
     /// process can host several sessions at once.
     sessions: Arc<DashMap<String, ()>>,
@@ -50,6 +54,7 @@ impl AcpClient {
         connection_id: String,
         agent: &AcpAgentDef,
         cwd: Option<&str>,
+        bot_id: Option<String>,
         sink: Arc<dyn EventSink>,
     ) -> Result<(Arc<Self>, Value), String> {
         let mut cmd = Command::new(&agent.command);
@@ -74,6 +79,7 @@ impl AcpClient {
             connection_id: connection_id.clone(),
             agent_id: agent.id.clone(),
             agent_name: agent.name.clone(),
+            bot_id,
             sessions: Arc::new(DashMap::new()),
             last_session: Mutex::new(None),
             replaying: Arc::new(DashMap::new()),
@@ -159,6 +165,7 @@ impl AcpClient {
             &self.agent_id,
             Some(&self.agent_name),
             cwd,
+            self.bot_id.as_deref(),
         ) {
             log::warn!("acp: failed to record session: {e}");
         }
@@ -186,6 +193,7 @@ impl AcpClient {
             &self.agent_id,
             Some(&self.agent_name),
             cwd,
+            self.bot_id.as_deref(),
         ) {
             log::warn!("acp: failed to record session: {e}");
         }

--- a/crates/acp/src/lib.rs
+++ b/crates/acp/src/lib.rs
@@ -7,7 +7,7 @@ pub mod agents;
 pub mod client;
 pub mod state;
 
-pub use agents::{AcpAgentDef, find_preset, list_agents};
+pub use agents::{AcpAgentDef, find_preset, install_preset, list_agents};
 /// Persisted session list and transcripts, stored by the client as it runs.
 pub use codexia_db::acp_sessions::{
     AcpSessionRecord, delete_session, get_updates, list_sessions,

--- a/crates/acp/src/state.rs
+++ b/crates/acp/src/state.rs
@@ -42,6 +42,7 @@ impl AcpState {
         agent_id: &str,
         cwd: &str,
         custom: Option<AcpAgentDef>,
+        bot_id: Option<String>,
     ) -> Result<AcpStartResult, String> {
         let agent = match custom {
             Some(a) => a,
@@ -50,7 +51,8 @@ impl AcpState {
 
         let connection_id = uuid::Uuid::new_v4().to_string();
         let (client, initialize) =
-            AcpClient::spawn(connection_id.clone(), &agent, Some(cwd), self.sink.clone()).await?;
+            AcpClient::spawn(connection_id.clone(), &agent, Some(cwd), bot_id, self.sink.clone())
+                .await?;
         self.connections.insert(connection_id.clone(), client.clone());
 
         let (session, session_error) = match client.new_session(cwd).await {

--- a/crates/acp/tests/smoke.rs
+++ b/crates/acp/tests/smoke.rs
@@ -20,7 +20,7 @@ impl EventSink for PrintSink {
 async fn gemini_prompt_roundtrip() {
     let state = AcpState::new(Arc::new(PrintSink));
     let cwd = std::env::temp_dir().display().to_string();
-    let started = state.start("gemini", &cwd, None).await.expect("start");
+    let started = state.start("gemini", &cwd, None, None).await.expect("start");
     println!("initialize: {}", started.initialize);
     assert!(
         started.session_id.is_some(),
@@ -66,7 +66,7 @@ async fn gemini_prompt_roundtrip() {
 async fn grok_reports_session_config() {
     let state = AcpState::new(Arc::new(PrintSink));
     let cwd = std::env::temp_dir().display().to_string();
-    let started = state.start("grok", &cwd, None).await.expect("start");
+    let started = state.start("grok", &cwd, None, None).await.expect("start");
     let session = started.session.expect("session/new result");
     println!("models: {}", session.get("models").unwrap_or(&Value::Null));
     println!("modes: {}", session.get("modes").unwrap_or(&Value::Null));

--- a/crates/db/src/acp_sessions.rs
+++ b/crates/db/src/acp_sessions.rs
@@ -12,6 +12,9 @@ pub struct AcpSessionRecord {
     pub agent_id: String,
     pub agent_title: Option<String>,
     pub cwd: String,
+    /// The bot this conversation belongs to, when it was opened from the Bot
+    /// tab. `None` for the ordinary per-project ACP sessions.
+    pub bot_id: Option<String>,
     /// First user message of the session, used as the list label.
     pub title: Option<String>,
     pub created_at: String,
@@ -27,18 +30,20 @@ pub fn upsert_session(
     agent_id: &str,
     agent_title: Option<&str>,
     cwd: &str,
+    bot_id: Option<&str>,
 ) -> Result<(), String> {
     let conn = get_connection()?;
     let now = Utc::now().to_rfc3339();
     conn.execute(
         "INSERT INTO acp_sessions (
-            session_id, agent_id, agent_title, cwd, title, created_at, updated_at
-        ) VALUES (?1, ?2, ?3, ?4, NULL, ?5, ?5)
+            session_id, agent_id, agent_title, cwd, bot_id, title, created_at, updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, ?6)
         ON CONFLICT(session_id) DO UPDATE SET
             agent_id = excluded.agent_id,
             agent_title = excluded.agent_title,
-            cwd = excluded.cwd",
-        params![session_id, agent_id, agent_title, cwd, now],
+            cwd = excluded.cwd,
+            bot_id = excluded.bot_id",
+        params![session_id, agent_id, agent_title, cwd, bot_id, now],
     )
     .map_err(|e| format!("Failed to upsert ACP session: {}", e))?;
     Ok(())
@@ -75,15 +80,17 @@ pub fn set_title_if_empty(session_id: &str, title: &str) -> Result<(), String> {
 }
 
 /// Sessions for `cwd`, or all of them when `cwd` is `None`, newest first.
+/// Bot conversations are left out: they belong to a bot, not to a project, and
+/// listing them beside the project's own sessions would show each twice.
 pub fn list_sessions(cwd: Option<&str>, limit: usize) -> Result<Vec<AcpSessionRecord>, String> {
     let conn = get_connection()?;
     let limit = if limit == 0 { 100 } else { limit.min(500) } as i64;
 
     let mut stmt = conn
         .prepare(
-            "SELECT session_id, agent_id, agent_title, cwd, title, created_at, updated_at
+            "SELECT session_id, agent_id, agent_title, cwd, bot_id, title, created_at, updated_at
              FROM acp_sessions
-             WHERE (?1 IS NULL OR cwd = ?1)
+             WHERE (?1 IS NULL OR cwd = ?1) AND bot_id IS NULL
              ORDER BY updated_at DESC
              LIMIT ?2",
         )
@@ -96,15 +103,51 @@ pub fn list_sessions(cwd: Option<&str>, limit: usize) -> Result<Vec<AcpSessionRe
                 agent_id: row.get(1)?,
                 agent_title: row.get(2)?,
                 cwd: row.get(3)?,
-                title: row.get(4)?,
-                created_at: row.get(5)?,
-                updated_at: row.get(6)?,
+                bot_id: row.get(4)?,
+                title: row.get(5)?,
+                created_at: row.get(6)?,
+                updated_at: row.get(7)?,
             })
         })
         .map_err(|e| format!("Failed to query ACP sessions: {}", e))?;
 
     rows.collect::<Result<Vec<_>, _>>()
         .map_err(|e| format!("Failed to read ACP sessions: {}", e))
+}
+
+/// One bot's conversations, newest first. Reads the table only — the sidebar
+/// must be able to show a bot without waking its agent process.
+pub fn list_bot_sessions(bot_id: &str, limit: usize) -> Result<Vec<AcpSessionRecord>, String> {
+    let conn = get_connection()?;
+    let limit = if limit == 0 { 100 } else { limit.min(500) } as i64;
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT session_id, agent_id, agent_title, cwd, bot_id, title, created_at, updated_at
+             FROM acp_sessions
+             WHERE bot_id = ?1
+             ORDER BY updated_at DESC
+             LIMIT ?2",
+        )
+        .map_err(|e| format!("Failed to prepare bot session list query: {}", e))?;
+
+    let rows = stmt
+        .query_map(params![bot_id, limit], |row| {
+            Ok(AcpSessionRecord {
+                session_id: row.get(0)?,
+                agent_id: row.get(1)?,
+                agent_title: row.get(2)?,
+                cwd: row.get(3)?,
+                bot_id: row.get(4)?,
+                title: row.get(5)?,
+                created_at: row.get(6)?,
+                updated_at: row.get(7)?,
+            })
+        })
+        .map_err(|e| format!("Failed to query bot sessions: {}", e))?;
+
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("Failed to read bot sessions: {}", e))
 }
 
 /// The stored transcript, in arrival order. Each item is a `session/update`

--- a/crates/db/src/bots.rs
+++ b/crates/db/src/bots.rs
@@ -1,0 +1,257 @@
+use chrono::Utc;
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+
+use super::get_connection;
+
+/// A bot: a named, long-lived agent you message like a colleague.
+///
+/// Everything here is Codexia's own. The runtime it drives (`keke agent stdio`)
+/// has no concept of a named agent, so identity, persona and tool selection are
+/// stored on this side and translated into spawn arguments and ACP config
+/// options when a conversation starts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BotRecord {
+    pub id: String,
+    pub name: String,
+    /// One-line role, shown under the name.
+    pub title: Option<String>,
+    /// Emoji drawn on the avatar circle.
+    pub avatar: String,
+    /// Hex background of the avatar circle.
+    pub color: String,
+    /// Which ACP agent backs the bot. Always `keke` today; stored so another
+    /// preset can be offered without a migration.
+    pub agent_id: String,
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub reasoning_effort: Option<String>,
+    pub cwd: String,
+    /// The persona, handed to keke as `KEKE_INSTRUCTIONS`.
+    pub system_prompt: Option<String>,
+    /// `read_only` | `ask` | `autonomous`.
+    pub trust_level: String,
+    /// Tool names this bot's owner has already approved for good, as a JSON
+    /// array. ACP's own `allow-always` only lasts a session, so the standing
+    /// answer is kept here instead.
+    pub approved_tools: String,
+    /// Servers to hand this bot at `session/new`, as a JSON array of names.
+    /// Per-conversation rather than per-installation, which is the only place
+    /// ACP lets a client name them.
+    pub mcp_servers: String,
+    pub pinned: bool,
+    pub archived: bool,
+    pub notifications_enabled: bool,
+    pub unread_count: i64,
+    pub last_viewed_at: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// The fields a caller may change. Anything left `None` keeps its stored value,
+/// so a dialog that edits one field does not have to send the whole record back.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BotPatch {
+    pub name: Option<String>,
+    pub title: Option<String>,
+    pub avatar: Option<String>,
+    pub color: Option<String>,
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub reasoning_effort: Option<String>,
+    pub cwd: Option<String>,
+    pub system_prompt: Option<String>,
+    pub trust_level: Option<String>,
+    pub approved_tools: Option<Vec<String>>,
+    pub mcp_servers: Option<Vec<String>>,
+    pub pinned: Option<bool>,
+    pub archived: Option<bool>,
+    pub notifications_enabled: Option<bool>,
+    pub unread_count: Option<i64>,
+    pub last_viewed_at: Option<String>,
+}
+
+const COLUMNS: &str = "id, name, title, avatar, color, agent_id, provider, model, \
+     reasoning_effort, cwd, system_prompt, trust_level, approved_tools, mcp_servers, \
+     pinned, archived, notifications_enabled, unread_count, \
+     last_viewed_at, created_at, updated_at";
+
+fn row_to_bot(row: &rusqlite::Row<'_>) -> rusqlite::Result<BotRecord> {
+    Ok(BotRecord {
+        id: row.get(0)?,
+        name: row.get(1)?,
+        title: row.get(2)?,
+        avatar: row.get(3)?,
+        color: row.get(4)?,
+        agent_id: row.get(5)?,
+        provider: row.get(6)?,
+        model: row.get(7)?,
+        reasoning_effort: row.get(8)?,
+        cwd: row.get(9)?,
+        system_prompt: row.get(10)?,
+        trust_level: row.get(11)?,
+        approved_tools: row.get(12)?,
+        mcp_servers: row.get(13)?,
+        pinned: row.get(14)?,
+        archived: row.get(15)?,
+        notifications_enabled: row.get(16)?,
+        unread_count: row.get(17)?,
+        last_viewed_at: row.get(18)?,
+        created_at: row.get(19)?,
+        updated_at: row.get(20)?,
+    })
+}
+
+/// A JSON array of strings, as the list columns are stored. An unreadable
+/// column reads as empty rather than failing the whole record: a bot with a
+/// corrupt tool list is still a bot you can open and fix.
+pub fn parse_list(raw: &str) -> Vec<String> {
+    serde_json::from_str(raw).unwrap_or_default()
+}
+
+fn encode_list(list: &[String]) -> String {
+    serde_json::to_string(list).unwrap_or_else(|_| "[]".to_string())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn create_bot(
+    id: &str,
+    name: &str,
+    avatar: &str,
+    color: &str,
+    agent_id: &str,
+    cwd: &str,
+    trust_level: &str,
+) -> Result<BotRecord, String> {
+    let conn = get_connection()?;
+    let now = Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT INTO bots (
+            id, name, title, avatar, color, agent_id, provider, model, reasoning_effort,
+            cwd, system_prompt, trust_level, approved_tools, mcp_servers,
+            pinned, archived, notifications_enabled, unread_count, last_viewed_at,
+            created_at, updated_at
+        ) VALUES (
+            ?1, ?2, NULL, ?3, ?4, ?5, NULL, NULL, NULL,
+            ?6, NULL, ?7, '[]', '[]',
+            0, 0, 1, 0, NULL,
+            ?8, ?8
+        )",
+        params![id, name, avatar, color, agent_id, cwd, trust_level, now],
+    )
+    .map_err(|e| format!("Failed to create bot: {}", e))?;
+
+    get_bot(id)?.ok_or_else(|| "Failed to read back the created bot".to_string())
+}
+
+pub fn get_bot(id: &str) -> Result<Option<BotRecord>, String> {
+    let conn = get_connection()?;
+    let mut stmt = conn
+        .prepare(&format!("SELECT {COLUMNS} FROM bots WHERE id = ?1"))
+        .map_err(|e| format!("Failed to prepare bot query: {}", e))?;
+    let mut rows = stmt
+        .query_map(params![id], row_to_bot)
+        .map_err(|e| format!("Failed to query bot: {}", e))?;
+    match rows.next() {
+        Some(row) => Ok(Some(
+            row.map_err(|e| format!("Failed to read bot: {}", e))?,
+        )),
+        None => Ok(None),
+    }
+}
+
+/// Every bot, pinned first and then by most recent activity — the order the
+/// sidebar shows them in. Reading this must never start an agent process, so
+/// it answers from the table alone.
+pub fn list_bots(include_archived: bool) -> Result<Vec<BotRecord>, String> {
+    let conn = get_connection()?;
+    let mut stmt = conn
+        .prepare(&format!(
+            "SELECT {COLUMNS} FROM bots
+             WHERE (?1 = 1 OR archived = 0)
+             ORDER BY pinned DESC, updated_at DESC"
+        ))
+        .map_err(|e| format!("Failed to prepare bot list query: {}", e))?;
+
+    let rows = stmt
+        .query_map(params![include_archived as i64], row_to_bot)
+        .map_err(|e| format!("Failed to query bots: {}", e))?;
+
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("Failed to read bots: {}", e))
+}
+
+/// Apply the fields the caller set. `updated_at` moves only when something
+/// actually changed, so opening a bot does not reorder the sidebar.
+pub fn update_bot(id: &str, patch: &BotPatch) -> Result<BotRecord, String> {
+    let conn = get_connection()?;
+
+    let mut sets: Vec<&str> = Vec::new();
+    let mut values: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+
+    macro_rules! set {
+        ($field:ident, $column:literal) => {
+            if let Some(value) = patch.$field.clone() {
+                sets.push(concat!($column, " = ?"));
+                values.push(Box::new(value));
+            }
+        };
+    }
+    macro_rules! set_list {
+        ($field:ident, $column:literal) => {
+            if let Some(list) = &patch.$field {
+                sets.push(concat!($column, " = ?"));
+                values.push(Box::new(encode_list(list)));
+            }
+        };
+    }
+
+    set!(name, "name");
+    set!(title, "title");
+    set!(avatar, "avatar");
+    set!(color, "color");
+    set!(provider, "provider");
+    set!(model, "model");
+    set!(reasoning_effort, "reasoning_effort");
+    set!(cwd, "cwd");
+    set!(system_prompt, "system_prompt");
+    set!(trust_level, "trust_level");
+    set_list!(approved_tools, "approved_tools");
+    set_list!(mcp_servers, "mcp_servers");
+    set!(pinned, "pinned");
+    set!(archived, "archived");
+    set!(notifications_enabled, "notifications_enabled");
+    set!(unread_count, "unread_count");
+    set!(last_viewed_at, "last_viewed_at");
+
+    if !sets.is_empty() {
+        sets.push("updated_at = ?");
+        values.push(Box::new(Utc::now().to_rfc3339()));
+        values.push(Box::new(id.to_string()));
+
+        let sql = format!("UPDATE bots SET {} WHERE id = ?", sets.join(", "));
+        let refs: Vec<&dyn rusqlite::ToSql> = values.iter().map(|v| v.as_ref()).collect();
+        conn.execute(&sql, refs.as_slice())
+            .map_err(|e| format!("Failed to update bot: {}", e))?;
+    }
+
+    get_bot(id)?.ok_or_else(|| format!("No bot with id `{id}`"))
+}
+
+/// Remove the bot and every conversation belonging to it, transcripts included.
+pub fn delete_bot(id: &str) -> Result<(), String> {
+    let conn = get_connection()?;
+    conn.execute(
+        "DELETE FROM acp_session_updates WHERE session_id IN
+         (SELECT session_id FROM acp_sessions WHERE bot_id = ?1)",
+        params![id],
+    )
+    .map_err(|e| format!("Failed to delete bot transcripts: {}", e))?;
+    conn.execute("DELETE FROM acp_sessions WHERE bot_id = ?1", params![id])
+        .map_err(|e| format!("Failed to delete bot sessions: {}", e))?;
+    conn.execute("DELETE FROM bots WHERE id = ?1", params![id])
+        .map_err(|e| format!("Failed to delete bot: {}", e))?;
+    Ok(())
+}

--- a/crates/db/src/conn.rs
+++ b/crates/db/src/conn.rs
@@ -24,6 +24,48 @@ fn init_tables(conn: &Connection) -> Result<(), String> {
     init_notes_table(conn)?;
     init_automation_runs_tables(conn)?;
     init_acp_sessions_tables(conn)?;
+    init_bots_table(conn)?;
+    Ok(())
+}
+
+/// Create the bot registry. Conversations are not stored here: a bot's history
+/// is its ACP sessions, tagged with `acp_sessions.bot_id`.
+fn init_bots_table(conn: &Connection) -> Result<(), String> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS bots (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            title TEXT,
+            avatar TEXT NOT NULL,
+            color TEXT NOT NULL,
+            agent_id TEXT NOT NULL,
+            provider TEXT,
+            model TEXT,
+            reasoning_effort TEXT,
+            cwd TEXT NOT NULL,
+            system_prompt TEXT,
+            trust_level TEXT NOT NULL,
+            approved_tools TEXT NOT NULL DEFAULT '[]',
+            mcp_servers TEXT NOT NULL DEFAULT '[]',
+            pinned BOOLEAN NOT NULL DEFAULT 0,
+            archived BOOLEAN NOT NULL DEFAULT 0,
+            notifications_enabled BOOLEAN NOT NULL DEFAULT 1,
+            unread_count INTEGER NOT NULL DEFAULT 0,
+            last_viewed_at TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )",
+        [],
+    )
+    .map_err(|e| format!("Failed to create bots table: {}", e))?;
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_bots_pinned_updated
+         ON bots(pinned DESC, updated_at DESC)",
+        [],
+    )
+    .map_err(|e| format!("Failed to create bots index: {}", e))?;
+
     Ok(())
 }
 
@@ -53,6 +95,21 @@ fn init_acp_sessions_tables(conn: &Connection) -> Result<(), String> {
         [],
     )
     .map_err(|e| format!("Failed to create acp_session_updates table: {}", e))?;
+
+    // Added after the table shipped, so an existing database gets it here.
+    if let Err(err) = conn.execute("ALTER TABLE acp_sessions ADD COLUMN bot_id TEXT", []) {
+        let message = err.to_string();
+        if !message.contains("duplicate column name") {
+            return Err(format!("Failed to add acp_sessions.bot_id column: {message}"));
+        }
+    }
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_acp_sessions_bot_updated
+         ON acp_sessions(bot_id, updated_at DESC)",
+        [],
+    )
+    .map_err(|e| format!("Failed to create acp_sessions bot index: {}", e))?;
 
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_acp_sessions_cwd_updated

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1,6 +1,7 @@
 mod conn;
 pub mod acp_sessions;
 pub mod automation_runs;
+pub mod bots;
 pub mod notes;
 
 pub(crate) use conn::get_connection;

--- a/src/components/acp/AcpChoiceMenu.tsx
+++ b/src/components/acp/AcpChoiceMenu.tsx
@@ -1,0 +1,230 @@
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Switch } from '@/components/ui/switch';
+import { useExternalUrl } from '@/features/plugins/hooks/useExternalUrl';
+import type { AcpAuthMethod, AcpConfigOption, AcpModelState } from '@/services/apiAdapt/acp';
+import { EFFORT_SEPARATOR, effortKey, modelChoicesFor } from './modelChoices';
+
+function findUrl(text: string): string | null {
+  return text.match(/https?:\/\/\S+/)?.[0] ?? null;
+}
+
+interface AcpChoiceMenuProps {
+  /** Accounts the agent advertises. Empty hides the Account submenu. */
+  authMethods: AcpAuthMethod[];
+  selectedAuthMethod: string | null;
+  onSelectAuthMethod: (methodId: string) => void;
+  /** Id of the account currently signing in, for the live composer only. */
+  authenticating?: string | null;
+  authNotice?: string | null;
+  configOptions: AcpConfigOption[];
+  onConfigOptionChange: (option: AcpConfigOption, value: string | boolean) => void;
+  models: AcpModelState | null;
+  reasoningEffort: string | null;
+  onModelChange: (modelId: string, effort: string | null) => void;
+  /** Name of the account row. Bots pick a provider rather than sign in. */
+  accountLabel?: string;
+  /** What the account row reads when nothing is picked. */
+  noAccountLabel?: string;
+  /** Shown on the trigger when nothing is picked yet. */
+  placeholder?: string;
+  triggerClassName?: string;
+}
+
+/**
+ * Account, model and reasoning effort in one dropdown — one trigger rather
+ * than a row of separate pickers.
+ *
+ * Presentation only: it renders whatever choices it is handed and reports
+ * picks back. `AcpModelMenu` wires it to a live connection (each pick is an
+ * immediate RPC); the bot settings dialog wires it to a stored draft for an
+ * agent that isn't running.
+ */
+export function AcpChoiceMenu({
+  authMethods,
+  selectedAuthMethod,
+  onSelectAuthMethod,
+  authenticating = null,
+  authNotice = null,
+  configOptions,
+  onConfigOptionChange,
+  models,
+  reasoningEffort,
+  onModelChange,
+  accountLabel: accountLabelText = 'Account',
+  noAccountLabel = 'Sign in',
+  placeholder = 'Model',
+  triggerClassName = 'flex max-w-40 items-center gap-1 truncate rounded-sm px-2 py-1 text-xs transition-colors hover:bg-accent',
+}: AcpChoiceMenuProps) {
+  const { openExternalUrl } = useExternalUrl();
+
+  const nonModeOptions = configOptions.filter((o) => o.category !== 'mode');
+  const modelChoices = modelChoicesFor(models);
+  const currentModelChoice = models
+    ? (modelChoices.find((c) => c.value === effortKey(models.currentModelId, reasoningEffort)) ??
+      modelChoices.find((c) => c.value.startsWith(models.currentModelId)))
+    : undefined;
+
+  if (nonModeOptions.length === 0 && modelChoices.length === 0 && authMethods.length === 0)
+    return null;
+
+  const modelCategoryOption = nonModeOptions.find(
+    (o) => o.category === 'model' || o.category === 'model_config'
+  );
+  const modelCategoryLabel = modelCategoryOption?.currentValue
+    ? (modelCategoryOption.options?.find((o) => o.value === modelCategoryOption.currentValue)
+        ?.name ?? String(modelCategoryOption.currentValue))
+    : null;
+  const effortCategoryOption = nonModeOptions.find((o) => o.category === 'thought_level');
+  const effortCategoryLabel = effortCategoryOption?.currentValue
+    ? (effortCategoryOption.options?.find((o) => o.value === effortCategoryOption.currentValue)
+        ?.name ?? String(effortCategoryOption.currentValue))
+    : null;
+  // `currentModelChoice.name` already folds the effort in for the legacy
+  // `models` mechanism (e.g. "Grok 4 · High"); the `configOptions` one keeps
+  // model and effort as separate options, so pair them here instead.
+  const modelLabel = modelCategoryLabel
+    ? effortCategoryLabel
+      ? `${modelCategoryLabel} · ${effortCategoryLabel}`
+      : modelCategoryLabel
+    : (currentModelChoice?.name ?? models?.currentModelId ?? null);
+  const accountLabel = authenticating
+    ? 'Signing in…'
+    : (authMethods.find((m) => m.id === selectedAuthMethod)?.name ??
+      (authMethods.length ? noAccountLabel : null));
+  const triggerLabel = modelLabel ?? accountLabel;
+
+  const noticeUrl = authNotice ? findUrl(authNotice) : null;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className={triggerClassName}>
+        {triggerLabel ?? placeholder}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="min-w-48 max-w-64" align="end">
+        <DropdownMenuGroup>
+          {authMethods.length > 0 && (
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                <div className="flex w-full items-center justify-between pr-1">
+                  <span>{accountLabelText}</span>
+                  <span className="text-xs font-normal text-muted-foreground">
+                    {accountLabel ?? noAccountLabel}
+                  </span>
+                </div>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="min-w-40 max-w-64">
+                <DropdownMenuLabel>{accountLabelText}</DropdownMenuLabel>
+                {authMethods.map((m) => (
+                  <DropdownMenuItem
+                    key={m.id}
+                    title={m.description ?? undefined}
+                    disabled={authenticating !== null}
+                    className={selectedAuthMethod === m.id ? 'bg-accent' : undefined}
+                    onSelect={(e) => {
+                      e.preventDefault();
+                      onSelectAuthMethod(m.id);
+                    }}
+                  >
+                    <span>{m.name}</span>
+                    {authenticating === m.id && (
+                      <span className="ml-auto text-xs text-muted-foreground">…</span>
+                    )}
+                  </DropdownMenuItem>
+                ))}
+                {authenticating && authNotice && (
+                  <div className="px-2 py-1 text-xs break-words text-muted-foreground">
+                    {noticeUrl ? (
+                      <button
+                        type="button"
+                        className="underline"
+                        onClick={() => openExternalUrl(noticeUrl)}
+                      >
+                        Open this link to sign in
+                      </button>
+                    ) : (
+                      authNotice
+                    )}
+                  </div>
+                )}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          )}
+
+          {nonModeOptions.map((option) =>
+            option.type === 'boolean' ? (
+              <label
+                key={option.id}
+                className="flex items-center gap-1 px-2 py-1.5 text-xs text-muted-foreground"
+                title={option.description}
+              >
+                <span className="flex-1">{option.name}</span>
+                <Switch
+                  checked={option.currentValue === true}
+                  onCheckedChange={(checked) => onConfigOptionChange(option, checked)}
+                />
+              </label>
+            ) : (
+              <DropdownMenuSub key={option.id}>
+                <DropdownMenuSubTrigger>
+                  <div className="flex w-full items-center justify-between pr-1">
+                    <span>{option.name}</span>
+                    <span className="text-xs font-normal text-muted-foreground">
+                      {String(option.currentValue ?? '')}
+                    </span>
+                  </div>
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent className="min-w-40 max-w-64">
+                  {(option.options ?? []).map((o) => (
+                    <DropdownMenuItem
+                      key={o.value}
+                      title={o.description}
+                      className={option.currentValue === o.value ? 'bg-accent' : undefined}
+                      onClick={() => onConfigOptionChange(option, o.value)}
+                    >
+                      {o.name}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+            )
+          )}
+
+          {configOptions.length === 0 && modelChoices.length > 0 && (
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                <div className="flex w-full items-center justify-between pr-1">
+                  <span>Model</span>
+                  <span className="max-w-28 truncate text-xs font-normal text-muted-foreground">
+                    {currentModelChoice?.name ?? models?.currentModelId}
+                  </span>
+                </div>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="min-w-48 max-w-72">
+                {modelChoices.map((c) => (
+                  <DropdownMenuItem
+                    key={c.value}
+                    title={c.description}
+                    className={currentModelChoice?.value === c.value ? 'bg-accent' : undefined}
+                    onClick={() => onModelChange(c.value.split(EFFORT_SEPARATOR)[0], c.effort)}
+                  >
+                    {c.name}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          )}
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/acp/AcpComposer.tsx
+++ b/src/components/acp/AcpComposer.tsx
@@ -24,7 +24,7 @@ export function AcpComposer() {
     restartNonce,
   } = useAcpStore();
   const cwd = useWorkspaceStore((s) => s.cwd);
-  const agents = useAcpAgents();
+  const agents = useAcpAgents() ?? [];
   const [text, setText] = useState('');
   // Agent we already tried to auto-connect, so a failed start does not spin in
   // a retry loop. Cleared on an explicit restart.

--- a/src/components/acp/AcpComposer.tsx
+++ b/src/components/acp/AcpComposer.tsx
@@ -5,6 +5,7 @@ import { toast } from '@/components/ui/use-toast';
 import { acpCancel, acpPrompt, acpStart } from '@/services/apiAdapt/acp';
 import { useWorkspaceStore } from '@/stores';
 import { useAcpStore } from '@/stores/useAcpStore';
+import { captureBotOptions } from '@/stores/useBotOptionsStore';
 import { AcpModelMenu } from './AcpModelMenu';
 import { AcpSessionControls } from './AcpSessionControls';
 import { useAcpAgents } from './useAcpAgents';
@@ -52,6 +53,9 @@ export function AcpComposer() {
         canLoadSession: res.initialize.agentCapabilities?.loadSession === true,
       });
       applySession(res.session);
+      // keke's own catalogue also configures bots, which are keke processes —
+      // so a bot can be set up from this session without opening its chat.
+      if (agentId === 'keke') captureBotOptions(res.initialize, res.session);
       if (res.sessionError) {
         addEntry({ id: `start-${Date.now()}`, role: 'error', text: res.sessionError });
         return null;

--- a/src/components/acp/AcpModelMenu.tsx
+++ b/src/components/acp/AcpModelMenu.tsx
@@ -1,17 +1,4 @@
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { Switch } from '@/components/ui/switch';
 import { toast } from '@/components/ui/use-toast';
-import { useExternalUrl } from '@/features/plugins/hooks/useExternalUrl';
 import {
   type AcpConfigOption,
   acpAuthenticate,
@@ -20,18 +7,8 @@ import {
 } from '@/services/apiAdapt/acp';
 import { useWorkspaceStore } from '@/stores';
 import { useAcpStore } from '@/stores/useAcpStore';
+import { AcpChoiceMenu } from './AcpChoiceMenu';
 import { acpFreshSession } from './newSession';
-
-type ChoiceOption = { value: string; name: string; description?: string; effort: string | null };
-
-/** Model id and reasoning effort share one select value. */
-const EFFORT_SEPARATOR = '::';
-const key = (modelId: string, effort: string | null) =>
-  effort ? `${modelId}${EFFORT_SEPARATOR}${effort}` : modelId;
-
-function findUrl(text: string): string | null {
-  return text.match(/https?:\/\/\S+/)?.[0] ?? null;
-}
 
 /** Loose match between an auth method id (e.g. "grok") and a model id/name it likely owns. */
 function ownedByMethod(text: string, methodId: string): boolean {
@@ -39,11 +16,9 @@ function ownedByMethod(text: string, methodId: string): boolean {
 }
 
 /**
- * Account, model and reasoning-effort in one dropdown — one trigger rather
- * than a row of separate pickers, mirroring grok-web-ui's `ModelSelector` /
- * `AccountMenu` split. Only `keke`'s `configOptions` path has been exercised
- * against a real agent; the legacy `models` flattening (Grok/Gemini) is
- * carried over unchanged from the previous per-slot control.
+ * The composer's account/model/effort menu, wired to the live connection:
+ * every pick is applied to the running agent straight away, and reverted if
+ * the agent rejects it. `AcpChoiceMenu` does the rendering.
  *
  * There is no `signedIn` status from the backend — `authenticate` is
  * fire-and-forget — so "Account" only reflects the last method we asked for
@@ -66,12 +41,10 @@ export function AcpModelMenu() {
     setAuthenticating,
     setSelectedAuthMethod,
   } = useAcpStore();
-  const { openExternalUrl } = useExternalUrl();
   const cwd = useWorkspaceStore((s) => s.cwd);
 
   if (!connectionId || !sessionId) return null;
 
-  // Update optimistically, then roll back if the agent rejects the change.
   const apply = async (revert: () => void, request: () => Promise<void>) => {
     try {
       await request();
@@ -81,9 +54,6 @@ export function AcpModelMenu() {
     }
   };
 
-  // Read the session id fresh rather than closing over the render-time one —
-  // `selectModelForMethod` calls these right after `acpFreshSession` swaps in
-  // a new session id, and targeting the stale one would fail silently.
   const changeConfigOption = (option: AcpConfigOption, value: string | boolean) => {
     const previous = option.currentValue;
     setConfigOptionValue(option.id, value);
@@ -107,10 +77,6 @@ export function AcpModelMenu() {
     );
   };
 
-  // After switching account, pick a model that actually belongs to it — a
-  // fresh session refreshes the *list*, but the agent's own "current" model
-  // may still be the old provider's, and the list can mix every provider's
-  // models together rather than filtering to the one just signed in to.
   const selectModelForMethod = async (methodId: string) => {
     const s = useAcpStore.getState();
     if (!s.connectionId || !s.sessionId) return;
@@ -124,10 +90,6 @@ export function AcpModelMenu() {
           (o) => ownedByMethod(o.value, methodId) || ownedByMethod(o.name, methodId)
         ) ?? modelOption.options[0];
       if (match.value !== modelOption.currentValue) {
-        // Effort choices can depend on the model (thought_level is often
-        // model-specific), so wait for the agent's response — and re-read the
-        // store rather than the `s` snapshot from before the change — instead
-        // of reading a list that was still the previous model's.
         await changeConfigOption(modelOption, match.value);
       }
       const effortOption = useAcpStore
@@ -171,180 +133,18 @@ export function AcpModelMenu() {
     }
   };
 
-  const nonModeOptions = configOptions.filter((o) => o.category !== 'mode');
-
-  // Effort belongs to a model, so expand each model that offers levels into
-  // one entry per level rather than pairing the picker with a second menu.
-  const modelChoices: ChoiceOption[] = (models?.availableModels ?? []).flatMap<ChoiceOption>(
-    (m) => {
-      const efforts = m._meta?.reasoningEfforts ?? [];
-      if (!efforts.length) {
-        return [{ value: m.modelId, name: m.name, description: m.description, effort: null }];
-      }
-      return efforts.map((e) => ({
-        value: key(m.modelId, e.id),
-        name: `${m.name} · ${(e.label ?? e.id).replace(/\s*effort$/i, '')}`,
-        description: e.description ?? m.description,
-        effort: e.id,
-      }));
-    }
-  );
-  const currentModelChoice = models
-    ? (modelChoices.find((c) => c.value === key(models.currentModelId, reasoningEffort)) ??
-      modelChoices.find((c) => c.value.startsWith(models.currentModelId)))
-    : undefined;
-
-  if (nonModeOptions.length === 0 && modelChoices.length === 0 && authMethods.length === 0)
-    return null;
-
-  const modelCategoryOption = nonModeOptions.find(
-    (o) => o.category === 'model' || o.category === 'model_config'
-  );
-  const modelCategoryLabel = modelCategoryOption
-    ? (modelCategoryOption.options?.find((o) => o.value === modelCategoryOption.currentValue)
-        ?.name ?? String(modelCategoryOption.currentValue))
-    : null;
-  const effortCategoryOption = nonModeOptions.find((o) => o.category === 'thought_level');
-  const effortCategoryLabel = effortCategoryOption
-    ? (effortCategoryOption.options?.find((o) => o.value === effortCategoryOption.currentValue)
-        ?.name ?? String(effortCategoryOption.currentValue))
-    : null;
-  // `currentModelChoice.name` already folds the effort in for the legacy
-  // `models` mechanism (e.g. "Grok 4 · High"); the `configOptions` one keeps
-  // model and effort as separate options, so pair them here instead.
-  const modelLabel = modelCategoryLabel
-    ? effortCategoryLabel
-      ? `${modelCategoryLabel} · ${effortCategoryLabel}`
-      : modelCategoryLabel
-    : (currentModelChoice?.name ?? models?.currentModelId ?? null);
-  const accountLabel = authenticating
-    ? 'Signing in…'
-    : (authMethods.find((m) => m.id === selectedAuthMethod)?.name ??
-      (authMethods.length ? 'Sign in' : null));
-  const triggerLabel = modelLabel ?? accountLabel;
-
-  const noticeUrl = authNotice ? findUrl(authNotice) : null;
-
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger className="flex max-w-40 items-center gap-1 truncate rounded-sm px-2 py-1 text-xs transition-colors hover:bg-accent">
-        {triggerLabel ?? 'Model'}
-      </DropdownMenuTrigger>
-      <DropdownMenuContent className="min-w-48 max-w-64" align="end">
-        <DropdownMenuGroup>
-          {authMethods.length > 0 && (
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger>
-                <div className="flex w-full items-center justify-between pr-1">
-                  <span>Account</span>
-                  <span className="text-xs font-normal text-muted-foreground">
-                    {accountLabel ?? 'Not signed in'}
-                  </span>
-                </div>
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent className="min-w-40 max-w-64">
-                <DropdownMenuLabel>Account</DropdownMenuLabel>
-                {authMethods.map((m) => (
-                  <DropdownMenuItem
-                    key={m.id}
-                    title={m.description ?? undefined}
-                    disabled={authenticating !== null}
-                    className={selectedAuthMethod === m.id ? 'bg-accent' : undefined}
-                    onSelect={(e) => {
-                      e.preventDefault();
-                      void signIn(m.id);
-                    }}
-                  >
-                    <span>{m.name}</span>
-                    {authenticating === m.id && (
-                      <span className="ml-auto text-xs text-muted-foreground">…</span>
-                    )}
-                  </DropdownMenuItem>
-                ))}
-                {authenticating && authNotice && (
-                  <div className="px-2 py-1 text-xs break-words text-muted-foreground">
-                    {noticeUrl ? (
-                      <button
-                        type="button"
-                        className="underline"
-                        onClick={() => openExternalUrl(noticeUrl)}
-                      >
-                        Open this link to sign in
-                      </button>
-                    ) : (
-                      authNotice
-                    )}
-                  </div>
-                )}
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-          )}
-
-          {nonModeOptions.map((option) =>
-            option.type === 'boolean' ? (
-              <label
-                key={option.id}
-                className="flex items-center gap-1 px-2 py-1.5 text-xs text-muted-foreground"
-                title={option.description}
-              >
-                <span className="flex-1">{option.name}</span>
-                <Switch
-                  checked={option.currentValue === true}
-                  onCheckedChange={(checked) => changeConfigOption(option, checked)}
-                />
-              </label>
-            ) : (
-              <DropdownMenuSub key={option.id}>
-                <DropdownMenuSubTrigger>
-                  <div className="flex w-full items-center justify-between pr-1">
-                    <span>{option.name}</span>
-                    <span className="text-xs font-normal text-muted-foreground">
-                      {String(option.currentValue)}
-                    </span>
-                  </div>
-                </DropdownMenuSubTrigger>
-                <DropdownMenuSubContent className="min-w-40 max-w-64">
-                  {(option.options ?? []).map((o) => (
-                    <DropdownMenuItem
-                      key={o.value}
-                      title={o.description}
-                      className={option.currentValue === o.value ? 'bg-accent' : undefined}
-                      onClick={() => changeConfigOption(option, o.value)}
-                    >
-                      {o.name}
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownMenuSubContent>
-              </DropdownMenuSub>
-            )
-          )}
-
-          {configOptions.length === 0 && modelChoices.length > 0 && (
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger>
-                <div className="flex w-full items-center justify-between pr-1">
-                  <span>Model</span>
-                  <span className="max-w-28 truncate text-xs font-normal text-muted-foreground">
-                    {currentModelChoice?.name ?? models?.currentModelId}
-                  </span>
-                </div>
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent className="min-w-48 max-w-72">
-                {modelChoices.map((c) => (
-                  <DropdownMenuItem
-                    key={c.value}
-                    title={c.description}
-                    className={currentModelChoice?.value === c.value ? 'bg-accent' : undefined}
-                    onClick={() => changeModel(c.value.split(EFFORT_SEPARATOR)[0], c.effort)}
-                  >
-                    {c.name}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-          )}
-        </DropdownMenuGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <AcpChoiceMenu
+      authMethods={authMethods}
+      selectedAuthMethod={selectedAuthMethod}
+      onSelectAuthMethod={(methodId) => void signIn(methodId)}
+      authenticating={authenticating}
+      authNotice={authNotice}
+      configOptions={configOptions}
+      onConfigOptionChange={changeConfigOption}
+      models={models}
+      reasoningEffort={reasoningEffort}
+      onModelChange={changeModel}
+    />
   );
 }

--- a/src/components/acp/AcpToolCall.test.tsx
+++ b/src/components/acp/AcpToolCall.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { AcpEntry } from '@/stores/useAcpStore';
+import { AcpToolCall } from './AcpToolCall';
+
+type ToolEntry = Extract<AcpEntry, { role: 'tool' }>;
+
+function toolEntry(overrides: Partial<ToolEntry>): ToolEntry {
+  return {
+    id: 't1',
+    role: 'tool',
+    toolCallId: 'call-1',
+    title: 'Run command',
+    status: 'completed',
+    ...overrides,
+  } as ToolEntry;
+}
+
+describe('AcpToolCall', () => {
+  it('shows the command of a shell call that already has output', () => {
+    render(
+      <AcpToolCall
+        entry={toolEntry({
+          kind: 'execute',
+          rawInput: { command: 'ls -la' },
+          content: [{ type: 'content', content: { type: 'text', text: 'total 0' } }],
+        })}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText(/ls -la/)).toBeTruthy();
+    expect(screen.getByText(/total 0/)).toBeTruthy();
+  });
+
+  it('joins an argv-style command', () => {
+    render(
+      <AcpToolCall
+        entry={toolEntry({ kind: 'execute', rawInput: { command: ['bash', '-lc', 'echo hi'] } })}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText(/bash -lc echo hi/)).toBeTruthy();
+  });
+
+  it('falls back to the raw input when the call is not a command', () => {
+    render(<AcpToolCall entry={toolEntry({ kind: 'read', rawInput: { path: '/tmp/a.txt' } })} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText(/\/tmp\/a.txt/)).toBeTruthy();
+  });
+});

--- a/src/components/acp/AcpToolCall.tsx
+++ b/src/components/acp/AcpToolCall.tsx
@@ -47,15 +47,34 @@ function ToolContent({ item }: { item: AcpToolContent }) {
 }
 
 /**
+ * The shell command a tool call runs, when it has one. Agents name the field
+ * differently (`command`, `cmd`) and some pass argv rather than a string.
+ */
+function commandOf(rawInput: unknown): string | null {
+  if (!rawInput || typeof rawInput !== 'object') return null;
+  const raw = rawInput as Record<string, unknown>;
+  const value = raw.command ?? raw.cmd;
+  if (typeof value === 'string') return value.trim() || null;
+  if (Array.isArray(value))
+    return value.filter((part) => typeof part === 'string').join(' ') || null;
+  return null;
+}
+
+/**
  * One ACP tool call: a title + status row that expands into whatever the agent
  * attached — diffs, command output, or the raw input when there is no content.
  */
 export function AcpToolCall({ entry }: { entry: ToolEntry }) {
   const [open, setOpen] = useState(false);
   const content = entry.content ?? [];
+  const command = commandOf(entry.rawInput);
+  // The command is what a shell call is about, so it stays visible even once
+  // output arrives; the raw JSON is only the fallback for calls with neither.
   const rawInput =
-    content.length === 0 && entry.rawInput ? JSON.stringify(entry.rawInput, null, 2) : null;
-  const expandable = content.length > 0 || rawInput !== null;
+    content.length === 0 && !command && entry.rawInput
+      ? JSON.stringify(entry.rawInput, null, 2)
+      : null;
+  const expandable = content.length > 0 || rawInput !== null || command !== null;
 
   return (
     <Collapsible open={open} onOpenChange={setOpen} className="rounded-md border">
@@ -82,6 +101,11 @@ export function AcpToolCall({ entry }: { entry: ToolEntry }) {
       </CollapsibleTrigger>
 
       <CollapsibleContent className="space-y-2 border-t px-2 py-2">
+        {command && (
+          <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-all rounded bg-muted/50 p-2 font-mono text-[11px]">
+            $ {command}
+          </pre>
+        )}
         {content.map((item, i) => (
           <ToolContent
             // biome-ignore lint/suspicious/noArrayIndexKey: append-only content stream, no stable id

--- a/src/components/acp/modelChoices.ts
+++ b/src/components/acp/modelChoices.ts
@@ -1,0 +1,34 @@
+import type { AcpModelState } from '@/services/apiAdapt/acp';
+
+export type ChoiceOption = {
+  value: string;
+  name: string;
+  description?: string;
+  effort: string | null;
+};
+
+/** Model id and reasoning effort share one select value. */
+export const EFFORT_SEPARATOR = '::';
+export const effortKey = (modelId: string, effort: string | null) =>
+  effort ? `${modelId}${EFFORT_SEPARATOR}${effort}` : modelId;
+
+/**
+ * Effort belongs to a model, so expand each model that offers levels into one
+ * entry per level rather than pairing the picker with a second menu. Only the
+ * legacy `models` mechanism (Grok/Gemini) needs this — `configOptions` keeps
+ * model and effort as separate options already.
+ */
+export function modelChoicesFor(models: AcpModelState | null): ChoiceOption[] {
+  return (models?.availableModels ?? []).flatMap<ChoiceOption>((m) => {
+    const efforts = m._meta?.reasoningEfforts ?? [];
+    if (!efforts.length) {
+      return [{ value: m.modelId, name: m.name, description: m.description, effort: null }];
+    }
+    return efforts.map((e) => ({
+      value: effortKey(m.modelId, e.id),
+      name: `${m.name} · ${(e.label ?? e.id).replace(/\s*effort$/i, '')}`,
+      description: e.description ?? m.description,
+      effort: e.id,
+    }));
+  });
+}

--- a/src/components/acp/useAcpAgents.ts
+++ b/src/components/acp/useAcpAgents.ts
@@ -1,22 +1,54 @@
 import { useEffect, useState } from 'react';
 import { type AcpAgentDef, acpListAgents } from '@/services/apiAdapt/acp';
 
-// The preset list is static for the lifetime of the app; fetch it once and
-// share it between the agent picker and the composer.
 let cache: AcpAgentDef[] | null = null;
 let inflight: Promise<AcpAgentDef[]> | null = null;
+const listeners = new Set<(agents: AcpAgentDef[]) => void>();
 
-export function useAcpAgents() {
-  const [agents, setAgents] = useState<AcpAgentDef[]>(cache ?? []);
+/**
+ * The resolved agent presets, or `null` while the first resolve is still in
+ * flight. `null` is deliberately distinct from `[]`: a caller must be able to
+ * tell "not known yet" from "nothing is installed", otherwise it renders an
+ * install prompt for an agent that is in fact present.
+ */
+export function useAcpAgents(): AcpAgentDef[] | null {
+  const [agents, setAgents] = useState<AcpAgentDef[] | null>(cache);
 
   useEffect(() => {
-    if (cache) return;
-    inflight ??= acpListAgents().catch(() => []);
-    inflight.then((list) => {
-      cache = list;
-      setAgents(list);
-    });
+    listeners.add(setAgents);
+    if (!cache) loadAcpAgents().then(setAgents);
+    return () => {
+      listeners.delete(setAgents);
+    };
   }, []);
 
   return agents;
+}
+
+/**
+ * The resolved list, awaited rather than read from React state. A component
+ * event handler (a message send, say) can fire before the hook's own effect
+ * has resolved its first render — awaiting this instead of trusting the
+ * hook's return value avoids treating "not loaded yet" as "not installed".
+ */
+export function loadAcpAgents(): Promise<AcpAgentDef[]> {
+  if (cache) return Promise.resolve(cache);
+  inflight ??= acpListAgents().catch(() => []);
+  return inflight.then((list) => {
+    cache = list;
+    return list;
+  });
+}
+
+/**
+ * Resolve the presets again from scratch. Availability is a PATH lookup made
+ * once per app run, so installing an agent while the app is open would
+ * otherwise keep reading as missing until a restart.
+ */
+export async function refreshAcpAgents(): Promise<AcpAgentDef[]> {
+  cache = null;
+  inflight = null;
+  const list = await loadAcpAgents();
+  for (const listener of listeners) listener(list);
+  return list;
 }

--- a/src/components/acp/useAcpEvents.ts
+++ b/src/components/acp/useAcpEvents.ts
@@ -59,6 +59,7 @@ export function useAcpEvents(connectionId: string | null) {
         store.setPermission({
           requestId: payload.requestId!,
           title,
+          toolKind: payload.toolCall?.kind as string | undefined,
           options: payload.options ?? [],
         });
         return;

--- a/src/components/agent/AgentSelector.tsx
+++ b/src/components/agent/AgentSelector.tsx
@@ -31,7 +31,7 @@ export function AgentSelector() {
   const { selectedAgent, setSelectedAgent } = useAgentSettingsStore();
   const { setActiveSidebarTab } = useLayoutStore();
   const { active, agentId, connectionId, setActive, setAgentId, reset } = useAcpStore();
-  const acpAgents = useAcpAgents();
+  const acpAgents = useAcpAgents() ?? [];
   const [open, setOpen] = useState(false);
 
   const current = active

--- a/src/components/bot/BotAvatar.tsx
+++ b/src/components/bot/BotAvatar.tsx
@@ -1,0 +1,32 @@
+import type { Bot } from '@/services/apiAdapt/bots';
+
+const SIZES = {
+  sm: 'h-7 w-7 text-sm',
+  md: 'h-9 w-9 text-base',
+  lg: 'h-11 w-11 text-xl',
+} as const;
+
+interface BotAvatarProps {
+  bot: Pick<Bot, 'avatar' | 'color' | 'name'>;
+  size?: keyof typeof SIZES;
+  /** Draws the ring that marks a bot whose agent process is live. */
+  running?: boolean;
+  className?: string;
+}
+
+export function BotAvatar({ bot, size = 'md', running, className }: BotAvatarProps) {
+  return (
+    <span
+      className={`flex shrink-0 items-center justify-center rounded-full text-white ${
+        SIZES[size]
+      } ${running ? 'ring-2 ring-emerald-500 ring-offset-1 ring-offset-background' : ''} ${
+        className ?? ''
+      }`}
+      style={{ backgroundColor: bot.color }}
+      title={bot.name}
+      aria-hidden
+    >
+      {bot.avatar}
+    </span>
+  );
+}

--- a/src/components/bot/BotChatView.tsx
+++ b/src/components/bot/BotChatView.tsx
@@ -1,0 +1,62 @@
+import { Settings2 } from 'lucide-react';
+import { useState } from 'react';
+import { useAcpEvents } from '@/components/acp/useAcpEvents';
+import { Button } from '@/components/ui/button';
+import { useAcpStore } from '@/stores/useAcpStore';
+import { useBotUiStore } from '@/stores/useBotUiStore';
+import { BotAvatar } from './BotAvatar';
+import { BotComposer } from './BotComposer';
+import { BotMessageList } from './BotMessageList';
+import { BotPermissionGate } from './BotPermissionGate';
+import { BotSettingsDialog } from './BotSettingsDialog';
+import { TRUST_LEVELS } from './botAgentDef';
+
+/** The full-screen conversation with one bot. */
+export default function BotChatView() {
+  const { bots, selectedBotId, connectionByBot } = useBotUiStore();
+  const connectionId = useAcpStore((s) => s.connectionId);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  useAcpEvents(connectionId);
+
+  const bot = bots.find((b) => b.id === selectedBotId);
+  if (!bot) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        Pick a bot, or make a new one.
+      </div>
+    );
+  }
+
+  const trust = TRUST_LEVELS.find((level) => level.id === bot.trustLevel);
+  const running = Boolean(connectionByBot[bot.id]);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <header className="flex shrink-0 items-center gap-2 border-b px-4 py-2">
+        <BotAvatar bot={bot} running={running} />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium">{bot.name}</div>
+          <div className="truncate text-xs text-muted-foreground">
+            {[bot.title, bot.model, trust?.label].filter(Boolean).join(' · ')}
+          </div>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          title="Bot settings"
+          onClick={() => setSettingsOpen(true)}
+        >
+          <Settings2 className="h-4 w-4" />
+        </Button>
+      </header>
+
+      <BotMessageList bot={bot} />
+      <BotPermissionGate bot={bot} />
+      <BotComposer bot={bot} />
+
+      <BotSettingsDialog bot={bot} open={settingsOpen} onOpenChange={setSettingsOpen} />
+    </div>
+  );
+}

--- a/src/components/bot/BotChatView.tsx
+++ b/src/components/bot/BotChatView.tsx
@@ -2,6 +2,8 @@ import { Settings2 } from 'lucide-react';
 import { useState } from 'react';
 import { useAcpEvents } from '@/components/acp/useAcpEvents';
 import { Button } from '@/components/ui/button';
+import { SidebarTrigger, useSidebar } from '@/components/ui/sidebar';
+import { useTrafficLightConfig } from '@/hooks';
 import { useAcpStore } from '@/stores/useAcpStore';
 import { useBotUiStore } from '@/stores/useBotUiStore';
 import { BotAvatar } from './BotAvatar';
@@ -10,16 +12,22 @@ import { BotMessageList } from './BotMessageList';
 import { BotPermissionGate } from './BotPermissionGate';
 import { BotSettingsDialog } from './BotSettingsDialog';
 import { TRUST_LEVELS } from './botAgentDef';
+import { useBotDragDrop } from './useBotDragDrop';
 
 /** The full-screen conversation with one bot. */
 export default function BotChatView() {
   const { bots, selectedBotId, connectionByBot } = useBotUiStore();
   const connectionId = useAcpStore((s) => s.connectionId);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const { open: isSidebarOpen, openMobile, isMobile } = useSidebar();
+  const showTrigger = isMobile ? !openMobile : !isSidebarOpen;
+  const { needsTrafficLightOffset } = useTrafficLightConfig(isSidebarOpen);
 
   useAcpEvents(connectionId);
 
   const bot = bots.find((b) => b.id === selectedBotId);
+  useBotDragDrop(bot);
+
   if (!bot) {
     return (
       <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
@@ -33,11 +41,24 @@ export default function BotChatView() {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <header className="flex shrink-0 items-center gap-2 border-b px-4 py-2">
+      <header
+        className="flex shrink-0 items-center gap-2 border-b py-2 pr-4"
+        data-tauri-drag-region
+        title="Drop a folder here to set this bot's workspace"
+      >
+        <div
+          className={`flex shrink-0 items-center gap-2 ${
+            showTrigger ? (needsTrafficLightOffset ? 'pl-20' : 'pl-2') : 'pl-4'
+          }`}
+        >
+          {showTrigger && <SidebarTrigger />}
+        </div>
         <BotAvatar bot={bot} running={running} />
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-medium">{bot.name}</div>
-          <div className="truncate text-xs text-muted-foreground">
+        <div className="min-w-0 flex-1" data-tauri-drag-region>
+          <div className="truncate text-sm font-medium" data-tauri-drag-region>
+            {bot.name}
+          </div>
+          <div className="truncate text-xs text-muted-foreground" data-tauri-drag-region>
             {[bot.title, bot.model, trust?.label].filter(Boolean).join(' · ')}
           </div>
         </div>

--- a/src/components/bot/BotComposer.tsx
+++ b/src/components/bot/BotComposer.tsx
@@ -10,10 +10,12 @@ import { BotKekeInstall } from './BotKekeInstall';
 import { useBotSession } from './useBotSession';
 
 export function BotComposer({ bot }: { bot: Bot }) {
-  const { connectionId, sessionId, connecting, running, setRunning, addEntry } = useAcpStore();
+  const { connectionId, connecting, setRunning, addEntry } = useAcpStore();
   const connectionByBot = useBotUiStore((s) => s.connectionByBot);
   const sessionByBot = useBotUiStore((s) => s.sessionByBot);
   const kekeSpawnFailed = useBotUiStore((s) => s.kekeSpawnFailed);
+  const running = useBotUiStore((s) => Boolean(s.runningByBot[bot.id]));
+  const setBotRunning = useBotUiStore((s) => s.setBotRunning);
   const { open } = useBotSession();
   const [text, setText] = useState('');
 
@@ -50,19 +52,27 @@ export function BotComposer({ bot }: { bot: Bot }) {
 
     setText('');
     addEntry({ id: `u-${Date.now()}`, role: 'user', text: trimmed });
+    setBotRunning(bot.id, true);
     setRunning(true);
     try {
       await acpPrompt(live.connectionId, live.sessionId, trimmed);
     } catch (e) {
-      addEntry({ id: `e-${Date.now()}`, role: 'error', text: String(e) });
+      // Only the bot on screen owns the ACP store: a turn that ends while the
+      // user is reading another bot must not write into that bot's pane.
+      if (useBotUiStore.getState().selectedBotId === bot.id) {
+        addEntry({ id: `e-${Date.now()}`, role: 'error', text: String(e) });
+      }
     } finally {
-      setRunning(false);
+      setBotRunning(bot.id, false);
+      if (useBotUiStore.getState().selectedBotId === bot.id) setRunning(false);
     }
   };
 
   const stop = async () => {
-    if (!connectionId) return;
-    await acpCancel(connectionId, sessionId).catch(() => {});
+    const connection = botConnection ?? connectionId;
+    if (!connection) return;
+    await acpCancel(connection, botSession ?? null).catch(() => {});
+    setBotRunning(bot.id, false);
     setRunning(false);
   };
 

--- a/src/components/bot/BotComposer.tsx
+++ b/src/components/bot/BotComposer.tsx
@@ -1,0 +1,104 @@
+import { ArrowUp, Square } from 'lucide-react';
+import { useState } from 'react';
+import { useAcpAgents } from '@/components/acp/useAcpAgents';
+import { Button } from '@/components/ui/button';
+import { acpCancel, acpPrompt } from '@/services/apiAdapt/acp';
+import type { Bot } from '@/services/apiAdapt/bots';
+import { useAcpStore } from '@/stores/useAcpStore';
+import { useBotUiStore } from '@/stores/useBotUiStore';
+import { BotKekeInstall } from './BotKekeInstall';
+import { useBotSession } from './useBotSession';
+
+export function BotComposer({ bot }: { bot: Bot }) {
+  const { connectionId, sessionId, connecting, running, setRunning, addEntry } = useAcpStore();
+  const connectionByBot = useBotUiStore((s) => s.connectionByBot);
+  const sessionByBot = useBotUiStore((s) => s.sessionByBot);
+  const kekeSpawnFailed = useBotUiStore((s) => s.kekeSpawnFailed);
+  const { open } = useBotSession();
+  const [text, setText] = useState('');
+
+  // Scoped to this bot: the ACP store can still hold another agent's live
+  // connection from the chat pane, which must not read as this bot's.
+  const botConnection = connectionByBot[bot.id];
+  const botSession = sessionByBot[bot.id];
+  const hasSession = Boolean(botConnection && botSession);
+
+  // `null` while the agent list is still resolving — only an actually resolved
+  // list saying keke is missing should replace the composer.
+  //
+  // `local`, not `available`: with Node installed keke always "resolves", via
+  // the `npx -y @milisp/keke@latest` fallback, which re-downloads the package
+  // on every spawn and is why a bot could sit there doing nothing instead of
+  // offering to install.
+  const agents = useAcpAgents();
+  const keke = agents?.find((a) => a.id === 'keke');
+  const kekeMissing = !hasSession && ((keke !== undefined && !keke.local) || kekeSpawnFailed);
+
+  if (kekeMissing) return <BotKekeInstall botName={bot.name} />;
+
+  const send = async () => {
+    const trimmed = text.trim();
+    if (!trimmed || running || connecting) return;
+
+    // Reuse this bot's own process when the store is already pointed at it;
+    // otherwise `open` restores or spawns it.
+    const live =
+      botConnection && botSession && connectionId === botConnection
+        ? { connectionId: botConnection, sessionId: botSession }
+        : await open(bot);
+    if (!live) return;
+
+    setText('');
+    addEntry({ id: `u-${Date.now()}`, role: 'user', text: trimmed });
+    setRunning(true);
+    try {
+      await acpPrompt(live.connectionId, live.sessionId, trimmed);
+    } catch (e) {
+      addEntry({ id: `e-${Date.now()}`, role: 'error', text: String(e) });
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const stop = async () => {
+    if (!connectionId) return;
+    await acpCancel(connectionId, sessionId).catch(() => {});
+    setRunning(false);
+  };
+
+  return (
+    <div className="shrink-0 border-t bg-background p-3">
+      <div className="flex items-end gap-2 rounded-2xl border px-3 py-2">
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => {
+            // `isComposing` is what keeps Enter from sending mid-word while an
+            // IME is still choosing characters.
+            if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+              e.preventDefault();
+              void send();
+            }
+          }}
+          placeholder={`Message ${bot.name}...`}
+          rows={1}
+          className="min-h-[24px] max-h-40 w-full resize-none bg-transparent text-base md:text-sm outline-none placeholder:text-muted-foreground"
+        />
+        {running ? (
+          <Button size="icon" variant="ghost" className="h-8 w-8 shrink-0" onClick={stop}>
+            <Square className="h-4 w-4" />
+          </Button>
+        ) : (
+          <Button
+            size="icon"
+            className="h-8 w-8 shrink-0 rounded-full"
+            disabled={!text.trim() || connecting}
+            onClick={() => void send()}
+          >
+            <ArrowUp className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/bot/BotIdentityFields.tsx
+++ b/src/components/bot/BotIdentityFields.tsx
@@ -1,3 +1,6 @@
+import { open } from '@tauri-apps/plugin-dialog';
+import { FolderOpen } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { BOT_AVATARS, BOT_COLORS } from './botDefaults';
@@ -28,6 +31,16 @@ export function BotIdentityFields({
   cwd,
   onCwdChange,
 }: BotIdentityFieldsProps) {
+  const pickWorkspace = async () => {
+    const selected = await open({
+      directory: true,
+      multiple: false,
+      defaultPath: cwd || undefined,
+    });
+    if (!selected || Array.isArray(selected)) return;
+    onCwdChange(selected);
+  };
+
   return (
     <>
       <div className="grid grid-cols-2 gap-3">
@@ -80,12 +93,17 @@ export function BotIdentityFields({
 
       <div className="space-y-1">
         <Label htmlFor="bot-cwd">Workspace</Label>
-        <Input
-          id="bot-cwd"
-          value={cwd}
-          placeholder="/path/to/project"
-          onChange={(e) => onCwdChange(e.target.value)}
-        />
+        <div className="flex gap-2">
+          <Input
+            id="bot-cwd"
+            value={cwd}
+            placeholder="/path/to/project"
+            onChange={(e) => onCwdChange(e.target.value)}
+          />
+          <Button type="button" variant="outline" size="icon" onClick={pickWorkspace}>
+            <FolderOpen className="h-4 w-4" />
+          </Button>
+        </div>
       </div>
     </>
   );

--- a/src/components/bot/BotIdentityFields.tsx
+++ b/src/components/bot/BotIdentityFields.tsx
@@ -1,0 +1,92 @@
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { BOT_AVATARS, BOT_COLORS } from './botDefaults';
+
+interface BotIdentityFieldsProps {
+  name: string;
+  onNameChange: (value: string) => void;
+  title: string;
+  onTitleChange: (value: string) => void;
+  avatar: string;
+  onAvatarChange: (value: string) => void;
+  color: string;
+  onColorChange: (value: string) => void;
+  cwd: string;
+  onCwdChange: (value: string) => void;
+}
+
+/** Who the bot is and where it works: name, role, look and workspace. */
+export function BotIdentityFields({
+  name,
+  onNameChange,
+  title,
+  onTitleChange,
+  avatar,
+  onAvatarChange,
+  color,
+  onColorChange,
+  cwd,
+  onCwdChange,
+}: BotIdentityFieldsProps) {
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1">
+          <Label htmlFor="bot-name">Name</Label>
+          <Input id="bot-name" value={name} onChange={(e) => onNameChange(e.target.value)} />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="bot-title">Role</Label>
+          <Input
+            id="bot-title"
+            value={title}
+            placeholder="What it does"
+            onChange={(e) => onTitleChange(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-1">
+        <Label>Avatar</Label>
+        <div className="flex flex-wrap gap-1">
+          {BOT_AVATARS.map((emoji) => (
+            <button
+              type="button"
+              key={emoji}
+              onClick={() => onAvatarChange(emoji)}
+              className={`flex h-8 w-8 items-center justify-center rounded-md border text-base ${
+                avatar === emoji ? 'border-primary bg-accent' : 'border-transparent'
+              }`}
+            >
+              {emoji}
+            </button>
+          ))}
+        </div>
+        <div className="flex flex-wrap gap-1 pt-1">
+          {BOT_COLORS.map((hex) => (
+            <button
+              type="button"
+              key={hex}
+              aria-label={`Colour ${hex}`}
+              onClick={() => onColorChange(hex)}
+              style={{ backgroundColor: hex }}
+              className={`h-6 w-6 rounded-full ${
+                color === hex ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-1">
+        <Label htmlFor="bot-cwd">Workspace</Label>
+        <Input
+          id="bot-cwd"
+          value={cwd}
+          placeholder="/path/to/project"
+          onChange={(e) => onCwdChange(e.target.value)}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/components/bot/BotKekeInstall.tsx
+++ b/src/components/bot/BotKekeInstall.tsx
@@ -1,0 +1,56 @@
+import { Loader2, Terminal } from 'lucide-react';
+import { useState } from 'react';
+import { refreshAcpAgents } from '@/components/acp/useAcpAgents';
+import { Button } from '@/components/ui/button';
+import { toast } from '@/components/ui/use-toast';
+import { acpInstallAgent } from '@/services/apiAdapt/acp';
+import { useBotUiStore } from '@/stores/useBotUiStore';
+
+/**
+ * Shown in the composer's place while keke cannot run, so the Bot tab explains
+ * itself where the user is already looking instead of through a toast.
+ */
+export function BotKekeInstall({ botName }: { botName: string }) {
+  const setKekeSpawnFailed = useBotUiStore((s) => s.setKekeSpawnFailed);
+  const [installing, setInstalling] = useState(false);
+
+  const install = async () => {
+    setInstalling(true);
+    try {
+      const agent = await acpInstallAgent('keke');
+      console.log('bot: keke install finished', agent);
+      await refreshAcpAgents();
+      // A fresh install means a fresh PATH lookup is worth trusting again.
+      if (agent.local) setKekeSpawnFailed(false);
+      else toast({ title: 'keke installed, but is still not on PATH', variant: 'destructive' });
+    } catch (e) {
+      toast({ title: 'Could not install keke', description: String(e), variant: 'destructive' });
+    } finally {
+      setInstalling(false);
+    }
+  };
+
+  return (
+    <div className="shrink-0 border-t bg-background p-3">
+      <div className="flex items-center gap-3 rounded-2xl border border-dashed px-3 py-3 text-sm text-muted-foreground">
+        <Terminal className="h-4 w-4 shrink-0" />
+        <span className="min-w-0 flex-1">
+          {botName} runs on the{' '}
+          <a
+            href="https://github.com/milisp/keke"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-foreground underline"
+          >
+            keke
+          </a>{' '}
+          agent, which isn't installed yet.
+        </span>
+        <Button size="sm" className="shrink-0" disabled={installing} onClick={() => void install()}>
+          {installing && <Loader2 className="mr-1 h-3 w-3 animate-spin" />}
+          {installing ? 'Installing...' : 'Install keke'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/bot/BotMessageList.tsx
+++ b/src/components/bot/BotMessageList.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from 'react';
+import { AcpToolCall } from '@/components/acp/AcpToolCall';
+import type { Bot } from '@/services/apiAdapt/bots';
+import { useAcpStore } from '@/stores/useAcpStore';
+import { BotAvatar } from './BotAvatar';
+
+/** The conversation, as chat bubbles: you on the right, the bot on the left. */
+export function BotMessageList({ bot }: { bot: Bot }) {
+  const { entries, connecting, running } = useAcpStore();
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the count is the trigger, not a value the effect reads
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [entries.length]);
+
+  return (
+    <div className="flex-1 min-h-0 overflow-y-auto px-4 py-3 space-y-2 text-sm">
+      {entries.length === 0 && !connecting && (
+        <div className="py-10 text-center text-muted-foreground">
+          <BotAvatar bot={bot} size="lg" className="mx-auto mb-2" />
+          <div className="font-medium text-foreground">{bot.name}</div>
+          {bot.title && <div className="text-xs">{bot.title}</div>}
+          <div className="mt-2 text-xs">Say something to get started.</div>
+        </div>
+      )}
+
+      {entries.map((entry) => {
+        if (entry.role === 'tool') {
+          return (
+            <div key={entry.id} className="max-w-[85%]">
+              <AcpToolCall entry={entry} />
+            </div>
+          );
+        }
+
+        if (entry.role === 'user') {
+          return (
+            <div key={entry.id} className="flex justify-end">
+              <div className="max-w-[80%] whitespace-pre-wrap rounded-2xl rounded-br-md bg-primary px-3 py-2 text-primary-foreground">
+                {entry.text}
+              </div>
+            </div>
+          );
+        }
+
+        if (entry.role === 'error') {
+          return (
+            <div key={entry.id} className="px-1 py-1 text-xs text-destructive">
+              {entry.text}
+            </div>
+          );
+        }
+
+        // A thought is the bot working, not the bot talking — kept quiet so the
+        // conversation still reads as a conversation.
+        if (entry.role === 'thought') {
+          return (
+            <div key={entry.id} className="px-1 text-xs italic text-muted-foreground">
+              {entry.text}
+            </div>
+          );
+        }
+
+        return (
+          <div key={entry.id} className="flex items-end gap-2">
+            <BotAvatar bot={bot} size="sm" />
+            <div className="max-w-[80%] whitespace-pre-wrap rounded-2xl rounded-bl-md bg-muted px-3 py-2">
+              {entry.text}
+            </div>
+          </div>
+        );
+      })}
+
+      {(connecting || running) && (
+        <div className="flex items-center gap-2 px-1 text-xs text-muted-foreground">
+          <BotAvatar bot={bot} size="sm" />
+          {connecting ? `Waking ${bot.name}…` : 'Typing…'}
+        </div>
+      )}
+
+      <div ref={bottomRef} />
+    </div>
+  );
+}

--- a/src/components/bot/BotMessageList.tsx
+++ b/src/components/bot/BotMessageList.tsx
@@ -2,11 +2,15 @@ import { useEffect, useRef } from 'react';
 import { AcpToolCall } from '@/components/acp/AcpToolCall';
 import type { Bot } from '@/services/apiAdapt/bots';
 import { useAcpStore } from '@/stores/useAcpStore';
+import { useBotUiStore } from '@/stores/useBotUiStore';
 import { BotAvatar } from './BotAvatar';
 
 /** The conversation, as chat bubbles: you on the right, the bot on the left. */
 export function BotMessageList({ bot }: { bot: Bot }) {
-  const { entries, connecting, running } = useAcpStore();
+  const { entries, connecting } = useAcpStore();
+  // Per-bot, so a turn running in another conversation does not show this bot
+  // as typing.
+  const running = useBotUiStore((s) => Boolean(s.runningByBot[bot.id]));
   const bottomRef = useRef<HTMLDivElement>(null);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: the count is the trigger, not a value the effect reads

--- a/src/components/bot/BotModelFields.tsx
+++ b/src/components/bot/BotModelFields.tsx
@@ -1,0 +1,94 @@
+import { AcpChoiceMenu } from '@/components/acp/AcpChoiceMenu';
+import { Label } from '@/components/ui/label';
+import { useBotOptionsStore } from '@/stores/useBotOptionsStore';
+
+interface BotModelFieldsProps {
+  provider: string;
+  onProviderChange: (value: string) => void;
+  model: string;
+  onModelChange: (value: string) => void;
+  reasoningEffort: string;
+  onReasoningEffortChange: (value: string) => void;
+}
+
+/**
+ * Account, model and reasoning effort for a bot — the composer's own
+ * `AcpChoiceMenu`, driven by the cached catalogue instead of a live agent.
+ * Picks land in the draft and are applied when the bot next starts, which is
+ * the only difference from the composer's copy.
+ */
+export function BotModelFields({
+  provider,
+  onProviderChange,
+  model,
+  onModelChange,
+  reasoningEffort,
+  onReasoningEffortChange,
+}: BotModelFieldsProps) {
+  const catalogueAuthMethods = useBotOptionsStore((s) => s.authMethods);
+  const catalogue = useBotOptionsStore((s) => s.configOptions);
+  const models = useBotOptionsStore((s) => s.models);
+
+  // The catalogue only carries what keke offers; what this bot has chosen
+  // lives in the draft, so the current values are grafted on here.
+  const configOptions = catalogue.map((option) => ({
+    ...option,
+    currentValue: option.category === 'thought_level' ? reasoningEffort : model,
+    options: [
+      { value: '', name: "keke's default", description: 'Whatever ~/.keke/config.toml selects' },
+      ...(option.options ?? []),
+    ],
+  }));
+
+  // A bot inherits keke's own `config.toml` choice unless it overrides one, so
+  // the provider row must be able to go back to "no override" — signing in is
+  // keke's business, not a bot setting.
+  const authMethods = catalogueAuthMethods.length
+    ? [
+        { id: '', name: "keke's default", description: 'Whatever ~/.keke/config.toml selects' },
+        ...catalogueAuthMethods,
+      ]
+    : [];
+
+  const known = authMethods.length > 0 || configOptions.length > 0 || models !== null;
+
+  return (
+    <div className="space-y-1">
+      <Label>Model</Label>
+      {known ? (
+        <div className="flex">
+          <AcpChoiceMenu
+            authMethods={authMethods}
+            selectedAuthMethod={provider || null}
+            onSelectAuthMethod={onProviderChange}
+            configOptions={configOptions}
+            onConfigOptionChange={(option, value) => {
+              if (typeof value !== 'string') return;
+              if (option.category === 'thought_level') onReasoningEffortChange(value);
+              else {
+                onModelChange(value);
+                // A model switch can invalidate the previous effort level.
+                onReasoningEffortChange('');
+              }
+            }}
+            models={models ? { ...models, currentModelId: model } : null}
+            reasoningEffort={reasoningEffort || null}
+            onModelChange={(modelId, effort) => {
+              onModelChange(modelId);
+              onReasoningEffortChange(effort ?? '');
+            }}
+            accountLabel="Provider"
+            noAccountLabel="keke's default"
+            placeholder="keke's default"
+            triggerClassName="flex max-w-full items-center gap-1 truncate rounded-md border border-input px-3 py-2 text-sm hover:bg-accent"
+          />
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          Open a bot's chat once so keke can report the accounts and models it offers — the picker
+          appears here afterwards, and until then the bot uses keke's defaults.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/bot/BotPermissionGate.tsx
+++ b/src/components/bot/BotPermissionGate.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { acpRespondPermission } from '@/services/apiAdapt/acp';
+import { type Bot, parseBotList, updateBot } from '@/services/apiAdapt/bots';
+import { useAcpStore } from '@/stores/useAcpStore';
+import { useBotUiStore } from '@/stores/useBotUiStore';
+
+/** What a standing approval is about. Falls back to the title when the agent
+ *  reported no category, so the whitelist is never keyed on nothing. */
+function approvalKey(title: string, toolKind?: string) {
+  return toolKind ?? title;
+}
+
+/**
+ * The bot's answer to a permission request.
+ *
+ * ACP's own `allow-always` lasts only as long as the session, which is no use
+ * to a bot that is meant to keep working across restarts — so the standing
+ * answer is stored on the bot and applied here. An auto-approval is always
+ * announced in the transcript: a bot that quietly widens its own permissions
+ * is exactly what the whitelist is supposed to make visible.
+ */
+export function BotPermissionGate({ bot }: { bot: Bot }) {
+  const { connectionId, permission, setPermission, addEntry } = useAcpStore();
+  const upsertBot = useBotUiStore((s) => s.upsertBot);
+  // The request already auto-answered, so a re-render cannot answer it twice.
+  const answered = useRef<string | null>(null);
+
+  const approved = parseBotList(bot.approvedTools);
+
+  useEffect(() => {
+    if (!permission || !connectionId) return;
+    if (answered.current === permission.requestId) return;
+
+    const key = approvalKey(permission.title, permission.toolKind);
+    if (!approved.includes(key)) return;
+
+    answered.current = permission.requestId;
+    setPermission(null);
+    addEntry({
+      id: `auto-${permission.requestId}`,
+      role: 'thought',
+      text: `Auto-approved ${key} — ${bot.name} has a standing approval for it.`,
+    });
+    void acpRespondPermission(connectionId, permission.requestId, 'allow');
+  }, [permission, connectionId, approved, setPermission, addEntry, bot.name]);
+
+  if (!permission || !connectionId) return null;
+
+  const key = approvalKey(permission.title, permission.toolKind);
+  if (approved.includes(key)) return null;
+
+  const respond = async (optionId: string | null) => {
+    setPermission(null);
+    await acpRespondPermission(connectionId, permission.requestId, optionId);
+  };
+
+  const allowAlways = async () => {
+    const next = [...approved, key];
+    setPermission(null);
+    await acpRespondPermission(connectionId, permission.requestId, 'allow');
+    try {
+      upsertBot(await updateBot(bot.id, { approvedTools: next }));
+    } catch (e) {
+      // The turn already went ahead; only the standing rule failed to stick.
+      addEntry({
+        id: `approve-${Date.now()}`,
+        role: 'error',
+        text: `Allowed this once, but could not remember it: ${String(e)}`,
+      });
+    }
+  };
+
+  return (
+    <div className="shrink-0 border-t bg-muted/30 p-3 space-y-2">
+      <div className="text-sm">{permission.title}</div>
+      <div className="flex flex-wrap items-center gap-2">
+        {permission.options.map((option) => (
+          <Button key={option.optionId} size="sm" onClick={() => respond(option.optionId)}>
+            {option.name}
+          </Button>
+        ))}
+        <Button size="sm" variant="outline" onClick={allowAlways}>
+          Always allow {key}
+        </Button>
+        <Button size="sm" variant="ghost" onClick={() => respond(null)}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/bot/BotSessionList.tsx
+++ b/src/components/bot/BotSessionList.tsx
@@ -1,0 +1,66 @@
+import { Loader2 } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import type { AcpSessionRecord } from '@/services/apiAdapt/acp';
+import type { Bot } from '@/services/apiAdapt/bots';
+import { listBotSessions } from '@/services/apiAdapt/bots';
+import { useAcpStore } from '@/stores/useAcpStore';
+import { formatThreadAge } from '@/utils/formatThreadAge';
+import { useBotSession } from './useBotSession';
+
+/** Persisted conversations belonging only to the open bot. */
+export function BotSessionList({ bot }: { bot: Bot }) {
+  const { open } = useBotSession();
+  const activeSessionId = useAcpStore((s) => s.sessionId);
+  const [sessions, setSessions] = useState<AcpSessionRecord[]>([]);
+  const [opening, setOpening] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setSessions(await listBotSessions(bot.id));
+    } catch (error) {
+      console.error('bots: failed to list sessions', error);
+    }
+  }, [bot.id]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const select = async (session: AcpSessionRecord) => {
+    if (session.sessionId === activeSessionId) return;
+    setOpening(session.sessionId);
+    try {
+      await open(bot, session);
+    } finally {
+      setOpening(null);
+      void refresh();
+    }
+  };
+
+  if (sessions.length < 2) return null;
+
+  return (
+    <div className="flex flex-col shrink-0 gap-1 overflow-y-auto border-b px-3 py-1.5 max-h-40">
+      {sessions.map((session) => (
+        <button
+          type="button"
+          key={session.sessionId}
+          disabled={opening !== null}
+          onClick={() => void select(session)}
+          className={`flex min-w-0 w-full shrink-0 items-baseline gap-1.5 rounded-md px-2 py-1 text-left text-xs transition-colors disabled:opacity-60 ${
+            session.sessionId === activeSessionId
+              ? 'bg-accent font-medium'
+              : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground'
+          }`}
+          title={session.title ?? 'New session'}
+        >
+          {opening === session.sessionId && <Loader2 className="h-3 w-3 shrink-0 animate-spin" />}
+          <span className="min-w-0 flex-1 truncate">{session.title ?? 'New session'}</span>
+          <span className="shrink-0 text-[10px] opacity-70">
+            {formatThreadAge(Math.floor(new Date(session.updatedAt).getTime() / 1000))}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/bot/BotSettingsDialog.tsx
+++ b/src/components/bot/BotSettingsDialog.tsx
@@ -1,0 +1,338 @@
+import { X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { SelectComponent as Select } from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { toast } from '@/components/ui/use-toast';
+import {
+  type Bot,
+  type BotTrustLevel,
+  deleteBot,
+  parseBotList,
+  updateBot,
+} from '@/services/apiAdapt/bots';
+import { useAcpStore } from '@/stores/useAcpStore';
+import { useBotUiStore } from '@/stores/useBotUiStore';
+import { TRUST_LEVELS } from './botAgentDef';
+import { BOT_AVATARS, BOT_COLORS } from './botDefaults';
+
+interface BotSettingsDialogProps {
+  bot: Bot;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function BotSettingsDialog({ bot, open, onOpenChange }: BotSettingsDialogProps) {
+  const { upsertBot, removeBot } = useBotUiStore();
+  // Accounts, models and reasoning efforts the live process actually offers.
+  // Only populated while *this* bot's connection is the one currently open —
+  // a bot that has never run, or isn't the live one, falls back to plain text.
+  const connectionId = useAcpStore((s) => s.connectionId);
+  const authMethods = useAcpStore((s) => s.authMethods);
+  const models = useAcpStore((s) => s.models);
+  const isLive = useBotUiStore(
+    (s) => Boolean(connectionId) && s.connectionByBot[bot.id] === connectionId
+  );
+
+  const [name, setName] = useState(bot.name);
+  const [title, setTitle] = useState(bot.title ?? '');
+  const [avatar, setAvatar] = useState(bot.avatar);
+  const [color, setColor] = useState(bot.color);
+  const [cwd, setCwd] = useState(bot.cwd);
+  const [provider, setProvider] = useState(bot.provider ?? '');
+  const [model, setModel] = useState(bot.model ?? '');
+  const [reasoningEffort, setReasoningEffort] = useState(bot.reasoningEffort ?? '');
+  const [systemPrompt, setSystemPrompt] = useState(bot.systemPrompt ?? '');
+  const [trustLevel, setTrustLevel] = useState<BotTrustLevel>(bot.trustLevel);
+  const [approvedTools, setApprovedTools] = useState(parseBotList(bot.approvedTools));
+  const [saving, setSaving] = useState(false);
+
+  // Reopening on another bot must not show the previous one's draft.
+  useEffect(() => {
+    if (!open) return;
+    setName(bot.name);
+    setTitle(bot.title ?? '');
+    setAvatar(bot.avatar);
+    setColor(bot.color);
+    setCwd(bot.cwd);
+    setProvider(bot.provider ?? '');
+    setModel(bot.model ?? '');
+    setReasoningEffort(bot.reasoningEffort ?? '');
+    setSystemPrompt(bot.systemPrompt ?? '');
+    setTrustLevel(bot.trustLevel);
+    setApprovedTools(parseBotList(bot.approvedTools));
+  }, [open, bot]);
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      upsertBot(
+        await updateBot(bot.id, {
+          name: name.trim() || bot.name,
+          title,
+          avatar,
+          color,
+          cwd,
+          provider,
+          model,
+          reasoningEffort,
+          systemPrompt,
+          trustLevel,
+          approvedTools,
+        })
+      );
+      onOpenChange(false);
+    } catch (e) {
+      toast({ title: 'Could not save', description: String(e), variant: 'destructive' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async () => {
+    try {
+      await deleteBot(bot.id);
+      removeBot(bot.id);
+      onOpenChange(false);
+    } catch (e) {
+      toast({ title: 'Could not delete', description: String(e), variant: 'destructive' });
+    }
+  };
+
+  const availableModels = isLive ? (models?.availableModels ?? []) : [];
+  const currentModelEfforts = availableModels.find((m) => m.modelId === model)?._meta
+    ?.reasoningEfforts;
+  // Bots don't hold a live account like the ACP composer's "Account" menu
+  // does, but the accounts the connected process actually offers are the
+  // realistic choices for `--provider`.
+  const providerOptions = isLive ? authMethods : [];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{bot.name}</DialogTitle>
+          <DialogDescription>
+            Settings take effect the next time this bot starts a conversation.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label htmlFor="bot-name">Name</Label>
+              <Input id="bot-name" value={name} onChange={(e) => setName(e.target.value)} />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="bot-title">Role</Label>
+              <Input
+                id="bot-title"
+                value={title}
+                placeholder="What it does"
+                onChange={(e) => setTitle(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <Label>Avatar</Label>
+            <div className="flex flex-wrap gap-1">
+              {BOT_AVATARS.map((emoji) => (
+                <button
+                  type="button"
+                  key={emoji}
+                  onClick={() => setAvatar(emoji)}
+                  className={`flex h-8 w-8 items-center justify-center rounded-md border text-base ${
+                    avatar === emoji ? 'border-primary bg-accent' : 'border-transparent'
+                  }`}
+                >
+                  {emoji}
+                </button>
+              ))}
+            </div>
+            <div className="flex flex-wrap gap-1 pt-1">
+              {BOT_COLORS.map((hex) => (
+                <button
+                  type="button"
+                  key={hex}
+                  aria-label={`Colour ${hex}`}
+                  onClick={() => setColor(hex)}
+                  style={{ backgroundColor: hex }}
+                  className={`h-6 w-6 rounded-full ${
+                    color === hex ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''
+                  }`}
+                />
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="bot-cwd">Workspace</Label>
+            <Input
+              id="bot-cwd"
+              value={cwd}
+              placeholder="/path/to/project"
+              onChange={(e) => setCwd(e.target.value)}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label htmlFor="bot-provider">Provider</Label>
+              {providerOptions.length > 0 ? (
+                <Select
+                  value={provider}
+                  onValueChange={setProvider}
+                  placeholder="keke's default"
+                  options={providerOptions.map((m) => ({ value: m.id, label: m.name }))}
+                />
+              ) : (
+                <Input
+                  id="bot-provider"
+                  value={provider}
+                  placeholder="keke's default"
+                  onChange={(e) => setProvider(e.target.value)}
+                />
+              )}
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="bot-model">Model</Label>
+              {availableModels.length > 0 ? (
+                <Select
+                  value={model}
+                  onValueChange={(value) => {
+                    setModel(value);
+                    // A model switch can invalidate the previous effort level.
+                    const efforts = availableModels.find((m) => m.modelId === value)?._meta
+                      ?.reasoningEfforts;
+                    setReasoningEffort(efforts?.find((e) => e.default)?.id ?? '');
+                  }}
+                  placeholder="provider's default"
+                  options={availableModels.map((m) => ({ value: m.modelId, label: m.name }))}
+                />
+              ) : (
+                <>
+                  <Input
+                    id="bot-model"
+                    value={model}
+                    list="bot-model-options"
+                    placeholder="provider's default"
+                    onChange={(e) => setModel(e.target.value)}
+                  />
+                  <datalist id="bot-model-options">
+                    {availableModels.map((m) => (
+                      <option key={m.modelId} value={m.modelId}>
+                        {m.name}
+                      </option>
+                    ))}
+                  </datalist>
+                </>
+              )}
+            </div>
+            {currentModelEfforts && currentModelEfforts.length > 0 && (
+              <div className="col-span-2 space-y-1">
+                <Label htmlFor="bot-effort">Reasoning effort</Label>
+                <Select
+                  value={reasoningEffort}
+                  onValueChange={setReasoningEffort}
+                  placeholder="model's default"
+                  options={currentModelEfforts.map((e) => ({
+                    value: e.id,
+                    label: e.label ?? e.id,
+                  }))}
+                />
+              </div>
+            )}
+          </div>
+          {!isLive && (
+            <p className="text-xs text-muted-foreground">
+              Open this bot's chat once to pick a provider and model from a live list — until then
+              these are typed in by hand.
+            </p>
+          )}
+
+          <div className="space-y-1">
+            <Label htmlFor="bot-prompt">Persona</Label>
+            <Textarea
+              id="bot-prompt"
+              rows={4}
+              value={systemPrompt}
+              placeholder="Who this bot is, and how it should work."
+              onChange={(e) => setSystemPrompt(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Read after keke's own identity and before the project's AGENTS.md, so the repository
+              still has the last word.
+            </p>
+          </div>
+
+          <div className="space-y-1">
+            <Label>Trust</Label>
+            <div className="space-y-1">
+              {TRUST_LEVELS.map((level) => (
+                <button
+                  type="button"
+                  key={level.id}
+                  onClick={() => setTrustLevel(level.id)}
+                  className={`flex w-full flex-col items-start rounded-md border px-3 py-2 text-left ${
+                    trustLevel === level.id ? 'border-primary bg-accent/60' : 'border-border'
+                  }`}
+                >
+                  <span className="text-sm font-medium">{level.label}</span>
+                  <span className="text-xs text-muted-foreground">{level.description}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {approvedTools.length > 0 && (
+            <div className="space-y-1">
+              <Label>Always allowed</Label>
+              <div className="flex flex-wrap gap-1">
+                {approvedTools.map((tool) => (
+                  <span
+                    key={tool}
+                    className="flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs"
+                  >
+                    {tool}
+                    <button
+                      type="button"
+                      aria-label={`Stop always allowing ${tool}`}
+                      onClick={() => setApprovedTools(approvedTools.filter((t) => t !== tool))}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="justify-between sm:justify-between">
+          <Button variant="ghost" className="text-destructive" onClick={remove}>
+            Delete bot
+          </Button>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button disabled={saving} onClick={save}>
+              Save
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/bot/BotSettingsDialog.tsx
+++ b/src/components/bot/BotSettingsDialog.tsx
@@ -1,5 +1,4 @@
-import { X } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -9,22 +8,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { SelectComponent as Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { toast } from '@/components/ui/use-toast';
-import {
-  type Bot,
-  type BotTrustLevel,
-  deleteBot,
-  parseBotList,
-  updateBot,
-} from '@/services/apiAdapt/bots';
-import { useAcpStore } from '@/stores/useAcpStore';
+import { type Bot, deleteBot, updateBot } from '@/services/apiAdapt/bots';
 import { useBotUiStore } from '@/stores/useBotUiStore';
-import { TRUST_LEVELS } from './botAgentDef';
-import { BOT_AVATARS, BOT_COLORS } from './botDefaults';
+import { BotIdentityFields } from './BotIdentityFields';
+import { BotModelFields } from './BotModelFields';
+import { BotTrustFields } from './BotTrustFields';
+import { useBotSettingsForm } from './useBotSettingsForm';
 
 interface BotSettingsDialogProps {
   bot: Bot;
@@ -34,63 +26,13 @@ interface BotSettingsDialogProps {
 
 export function BotSettingsDialog({ bot, open, onOpenChange }: BotSettingsDialogProps) {
   const { upsertBot, removeBot } = useBotUiStore();
-  // Accounts, models and reasoning efforts the live process actually offers.
-  // Only populated while *this* bot's connection is the one currently open —
-  // a bot that has never run, or isn't the live one, falls back to plain text.
-  const connectionId = useAcpStore((s) => s.connectionId);
-  const authMethods = useAcpStore((s) => s.authMethods);
-  const models = useAcpStore((s) => s.models);
-  const isLive = useBotUiStore(
-    (s) => Boolean(connectionId) && s.connectionByBot[bot.id] === connectionId
-  );
-
-  const [name, setName] = useState(bot.name);
-  const [title, setTitle] = useState(bot.title ?? '');
-  const [avatar, setAvatar] = useState(bot.avatar);
-  const [color, setColor] = useState(bot.color);
-  const [cwd, setCwd] = useState(bot.cwd);
-  const [provider, setProvider] = useState(bot.provider ?? '');
-  const [model, setModel] = useState(bot.model ?? '');
-  const [reasoningEffort, setReasoningEffort] = useState(bot.reasoningEffort ?? '');
-  const [systemPrompt, setSystemPrompt] = useState(bot.systemPrompt ?? '');
-  const [trustLevel, setTrustLevel] = useState<BotTrustLevel>(bot.trustLevel);
-  const [approvedTools, setApprovedTools] = useState(parseBotList(bot.approvedTools));
+  const form = useBotSettingsForm(bot, open);
   const [saving, setSaving] = useState(false);
-
-  // Reopening on another bot must not show the previous one's draft.
-  useEffect(() => {
-    if (!open) return;
-    setName(bot.name);
-    setTitle(bot.title ?? '');
-    setAvatar(bot.avatar);
-    setColor(bot.color);
-    setCwd(bot.cwd);
-    setProvider(bot.provider ?? '');
-    setModel(bot.model ?? '');
-    setReasoningEffort(bot.reasoningEffort ?? '');
-    setSystemPrompt(bot.systemPrompt ?? '');
-    setTrustLevel(bot.trustLevel);
-    setApprovedTools(parseBotList(bot.approvedTools));
-  }, [open, bot]);
 
   const save = async () => {
     setSaving(true);
     try {
-      upsertBot(
-        await updateBot(bot.id, {
-          name: name.trim() || bot.name,
-          title,
-          avatar,
-          color,
-          cwd,
-          provider,
-          model,
-          reasoningEffort,
-          systemPrompt,
-          trustLevel,
-          approvedTools,
-        })
-      );
+      upsertBot(await updateBot(bot.id, form.patch));
       onOpenChange(false);
     } catch (e) {
       toast({ title: 'Could not save', description: String(e), variant: 'destructive' });
@@ -109,14 +51,6 @@ export function BotSettingsDialog({ bot, open, onOpenChange }: BotSettingsDialog
     }
   };
 
-  const availableModels = isLive ? (models?.availableModels ?? []) : [];
-  const currentModelEfforts = availableModels.find((m) => m.modelId === model)?._meta
-    ?.reasoningEfforts;
-  // Bots don't hold a live account like the ACP composer's "Account" menu
-  // does, but the accounts the connected process actually offers are the
-  // realistic choices for `--provider`.
-  const providerOptions = isLive ? authMethods : [];
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
@@ -128,147 +62,36 @@ export function BotSettingsDialog({ bot, open, onOpenChange }: BotSettingsDialog
         </DialogHeader>
 
         <div className="space-y-4">
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1">
-              <Label htmlFor="bot-name">Name</Label>
-              <Input id="bot-name" value={name} onChange={(e) => setName(e.target.value)} />
-            </div>
-            <div className="space-y-1">
-              <Label htmlFor="bot-title">Role</Label>
-              <Input
-                id="bot-title"
-                value={title}
-                placeholder="What it does"
-                onChange={(e) => setTitle(e.target.value)}
-              />
-            </div>
-          </div>
+          <BotIdentityFields
+            name={form.name}
+            onNameChange={form.setName}
+            title={form.title}
+            onTitleChange={form.setTitle}
+            avatar={form.avatar}
+            onAvatarChange={form.setAvatar}
+            color={form.color}
+            onColorChange={form.setColor}
+            cwd={form.cwd}
+            onCwdChange={form.setCwd}
+          />
 
-          <div className="space-y-1">
-            <Label>Avatar</Label>
-            <div className="flex flex-wrap gap-1">
-              {BOT_AVATARS.map((emoji) => (
-                <button
-                  type="button"
-                  key={emoji}
-                  onClick={() => setAvatar(emoji)}
-                  className={`flex h-8 w-8 items-center justify-center rounded-md border text-base ${
-                    avatar === emoji ? 'border-primary bg-accent' : 'border-transparent'
-                  }`}
-                >
-                  {emoji}
-                </button>
-              ))}
-            </div>
-            <div className="flex flex-wrap gap-1 pt-1">
-              {BOT_COLORS.map((hex) => (
-                <button
-                  type="button"
-                  key={hex}
-                  aria-label={`Colour ${hex}`}
-                  onClick={() => setColor(hex)}
-                  style={{ backgroundColor: hex }}
-                  className={`h-6 w-6 rounded-full ${
-                    color === hex ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''
-                  }`}
-                />
-              ))}
-            </div>
-          </div>
-
-          <div className="space-y-1">
-            <Label htmlFor="bot-cwd">Workspace</Label>
-            <Input
-              id="bot-cwd"
-              value={cwd}
-              placeholder="/path/to/project"
-              onChange={(e) => setCwd(e.target.value)}
-            />
-          </div>
-
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1">
-              <Label htmlFor="bot-provider">Provider</Label>
-              {providerOptions.length > 0 ? (
-                <Select
-                  value={provider}
-                  onValueChange={setProvider}
-                  placeholder="keke's default"
-                  options={providerOptions.map((m) => ({ value: m.id, label: m.name }))}
-                />
-              ) : (
-                <Input
-                  id="bot-provider"
-                  value={provider}
-                  placeholder="keke's default"
-                  onChange={(e) => setProvider(e.target.value)}
-                />
-              )}
-            </div>
-            <div className="space-y-1">
-              <Label htmlFor="bot-model">Model</Label>
-              {availableModels.length > 0 ? (
-                <Select
-                  value={model}
-                  onValueChange={(value) => {
-                    setModel(value);
-                    // A model switch can invalidate the previous effort level.
-                    const efforts = availableModels.find((m) => m.modelId === value)?._meta
-                      ?.reasoningEfforts;
-                    setReasoningEffort(efforts?.find((e) => e.default)?.id ?? '');
-                  }}
-                  placeholder="provider's default"
-                  options={availableModels.map((m) => ({ value: m.modelId, label: m.name }))}
-                />
-              ) : (
-                <>
-                  <Input
-                    id="bot-model"
-                    value={model}
-                    list="bot-model-options"
-                    placeholder="provider's default"
-                    onChange={(e) => setModel(e.target.value)}
-                  />
-                  <datalist id="bot-model-options">
-                    {availableModels.map((m) => (
-                      <option key={m.modelId} value={m.modelId}>
-                        {m.name}
-                      </option>
-                    ))}
-                  </datalist>
-                </>
-              )}
-            </div>
-            {currentModelEfforts && currentModelEfforts.length > 0 && (
-              <div className="col-span-2 space-y-1">
-                <Label htmlFor="bot-effort">Reasoning effort</Label>
-                <Select
-                  value={reasoningEffort}
-                  onValueChange={setReasoningEffort}
-                  placeholder="model's default"
-                  options={currentModelEfforts.map((e) => ({
-                    value: e.id,
-                    label: e.label ?? e.id,
-                  }))}
-                />
-              </div>
-            )}
-          </div>
-          {!isLive && (
-            <p className="text-xs text-muted-foreground">
-              Open this bot's chat once to pick a provider and model from a live list — until then
-              these are typed in by hand.
-            </p>
-          )}
+          <BotModelFields
+            provider={form.provider}
+            onProviderChange={form.setProvider}
+            model={form.model}
+            onModelChange={form.setModel}
+            reasoningEffort={form.reasoningEffort}
+            onReasoningEffortChange={form.setReasoningEffort}
+          />
 
           <div className="space-y-1">
             <Label htmlFor="bot-prompt">Persona</Label>
             <Textarea
               id="bot-prompt"
               rows={4}
-              value={systemPrompt}
+              value={form.systemPrompt}
               placeholder="Who this bot is, and how it should work."
-              onChange={(e) => setSystemPrompt(e.target.value)}
+              onChange={(e) => form.setSystemPrompt(e.target.value)}
             />
             <p className="text-xs text-muted-foreground">
               Read after keke's own identity and before the project's AGENTS.md, so the repository
@@ -276,47 +99,12 @@ export function BotSettingsDialog({ bot, open, onOpenChange }: BotSettingsDialog
             </p>
           </div>
 
-          <div className="space-y-1">
-            <Label>Trust</Label>
-            <div className="space-y-1">
-              {TRUST_LEVELS.map((level) => (
-                <button
-                  type="button"
-                  key={level.id}
-                  onClick={() => setTrustLevel(level.id)}
-                  className={`flex w-full flex-col items-start rounded-md border px-3 py-2 text-left ${
-                    trustLevel === level.id ? 'border-primary bg-accent/60' : 'border-border'
-                  }`}
-                >
-                  <span className="text-sm font-medium">{level.label}</span>
-                  <span className="text-xs text-muted-foreground">{level.description}</span>
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {approvedTools.length > 0 && (
-            <div className="space-y-1">
-              <Label>Always allowed</Label>
-              <div className="flex flex-wrap gap-1">
-                {approvedTools.map((tool) => (
-                  <span
-                    key={tool}
-                    className="flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs"
-                  >
-                    {tool}
-                    <button
-                      type="button"
-                      aria-label={`Stop always allowing ${tool}`}
-                      onClick={() => setApprovedTools(approvedTools.filter((t) => t !== tool))}
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
-                  </span>
-                ))}
-              </div>
-            </div>
-          )}
+          <BotTrustFields
+            trustLevel={form.trustLevel}
+            onTrustLevelChange={form.setTrustLevel}
+            approvedTools={form.approvedTools}
+            onApprovedToolsChange={form.setApprovedTools}
+          />
         </div>
 
         <DialogFooter className="justify-between sm:justify-between">

--- a/src/components/bot/BotTrustFields.tsx
+++ b/src/components/bot/BotTrustFields.tsx
@@ -1,0 +1,65 @@
+import { X } from 'lucide-react';
+import { Label } from '@/components/ui/label';
+import type { BotTrustLevel } from '@/services/apiAdapt/bots';
+import { TRUST_LEVELS } from './botAgentDef';
+
+interface BotTrustFieldsProps {
+  trustLevel: BotTrustLevel;
+  onTrustLevelChange: (level: BotTrustLevel) => void;
+  approvedTools: string[];
+  onApprovedToolsChange: (tools: string[]) => void;
+}
+
+/** How much the bot may do on its own, and the tools it never asks about. */
+export function BotTrustFields({
+  trustLevel,
+  onTrustLevelChange,
+  approvedTools,
+  onApprovedToolsChange,
+}: BotTrustFieldsProps) {
+  return (
+    <>
+      <div className="space-y-1">
+        <Label>Trust</Label>
+        <div className="space-y-1">
+          {TRUST_LEVELS.map((level) => (
+            <button
+              type="button"
+              key={level.id}
+              onClick={() => onTrustLevelChange(level.id)}
+              className={`flex w-full flex-col items-start rounded-md border px-3 py-2 text-left ${
+                trustLevel === level.id ? 'border-primary bg-accent/60' : 'border-border'
+              }`}
+            >
+              <span className="text-sm font-medium">{level.label}</span>
+              <span className="text-xs text-muted-foreground">{level.description}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {approvedTools.length > 0 && (
+        <div className="space-y-1">
+          <Label>Always allowed</Label>
+          <div className="flex flex-wrap gap-1">
+            {approvedTools.map((tool) => (
+              <span
+                key={tool}
+                className="flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs"
+              >
+                {tool}
+                <button
+                  type="button"
+                  aria-label={`Stop always allowing ${tool}`}
+                  onClick={() => onApprovedToolsChange(approvedTools.filter((t) => t !== tool))}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/bot/SideBarBotPane.test.tsx
+++ b/src/components/bot/SideBarBotPane.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAcpStore } from '@/stores/useAcpStore';
+import { useBotUiStore } from '@/stores/useBotUiStore';
+
+const createBot = vi.fn();
+
+vi.mock('@/services/apiAdapt/bots', () => ({
+  listBots: vi.fn().mockResolvedValue([]),
+  createBot: (...args: unknown[]) => createBot(...args),
+  listBotSessions: vi.fn().mockResolvedValue([]),
+  updateBot: vi.fn(),
+  deleteBot: vi.fn(),
+  parseBotList: () => [],
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('./BotSettingsDialog', () => ({ BotSettingsDialog: () => null }));
+
+import { SideBarBotPane } from './SideBarBotPane';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useAcpStore.getState().reset();
+  useBotUiStore.setState({ bots: [], selectedBotId: null, connectionByBot: {}, sessionByBot: {} });
+});
+
+describe('SideBarBotPane', () => {
+  it('clears the pane when a bot is created, so the previous bot does not appear to be it', async () => {
+    createBot.mockImplementation(async (bot: Record<string, unknown>) => ({
+      ...bot,
+      title: null,
+      agentId: 'keke',
+      provider: null,
+      model: null,
+      reasoningEffort: null,
+      systemPrompt: null,
+      trustLevel: 'ask',
+      approvedTools: '[]',
+      mcpServers: '[]',
+      pinned: false,
+      archived: false,
+      notificationsEnabled: true,
+      unreadCount: 0,
+      lastViewedAt: null,
+      createdAt: '',
+      updatedAt: new Date().toISOString(),
+    }));
+    // What the previously open bot left in the shared ACP store.
+    useAcpStore.getState().setEntries([{ id: 'a', role: 'agent', text: 'bot1 was talking' }]);
+
+    render(<SideBarBotPane />);
+    fireEvent.click(screen.getByText('newBot'));
+
+    await waitFor(() => expect(useAcpStore.getState().entries).toEqual([]));
+    expect(useBotUiStore.getState().selectedBotId).toBeTruthy();
+  });
+});

--- a/src/components/bot/SideBarBotPane.tsx
+++ b/src/components/bot/SideBarBotPane.tsx
@@ -1,0 +1,114 @@
+import { Plus } from 'lucide-react';
+import { useCallback, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { toast } from '@/components/ui/use-toast';
+import { type Bot, createBot, listBots } from '@/services/apiAdapt/bots';
+import { useLayoutStore } from '@/stores';
+import { useBotUiStore } from '@/stores/useBotUiStore';
+import { useWorkspaceStore } from '@/stores/useWorkspaceStore';
+import { BotAvatar } from './BotAvatar';
+import { defaultLook, newBotId } from './botDefaults';
+import { useBotSession } from './useBotSession';
+
+/** "3m", "4h", "2d" — enough to place a conversation without a full date. */
+function since(iso: string) {
+  const seconds = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000);
+  if (seconds < 60) return 'now';
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
+  return `${Math.floor(seconds / 86400)}d`;
+}
+
+/**
+ * The bot list: one flat, most-recent-first column, the way a messages app
+ * shows conversations. Reading it never starts an agent — a bot's process only
+ * wakes when you open it.
+ */
+export function SideBarBotPane() {
+  const { t } = useTranslation('sidebar');
+  const { bots, setBots, upsertBot, selectedBotId, connectionByBot } = useBotUiStore();
+  const setView = useLayoutStore((s) => s.setView);
+  const cwd = useWorkspaceStore((s) => s.cwd);
+  const { open } = useBotSession();
+
+  useEffect(() => {
+    listBots()
+      .then(setBots)
+      .catch((e) => console.error('bots: failed to list', e));
+  }, [setBots]);
+
+  const create = useCallback(async () => {
+    const look = defaultLook(bots.length);
+    try {
+      const bot = await createBot({
+        id: newBotId(),
+        name: `Bot ${bots.length + 1}`,
+        avatar: look.avatar,
+        color: look.color,
+        cwd: cwd ?? '',
+      });
+      upsertBot(bot);
+      useBotUiStore.getState().setSelectedBotId(bot.id);
+      setView('bot');
+    } catch (e) {
+      toast({ title: 'Could not create bot', description: String(e), variant: 'destructive' });
+    }
+  }, [bots.length, cwd, setView, upsertBot]);
+
+  const select = useCallback(
+    (bot: Bot) => {
+      setView('bot');
+      void open(bot);
+    },
+    [open, setView]
+  );
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="px-1 pb-1">
+        <Button variant="ghost" size="sm" className="w-full justify-start gap-2" onClick={create}>
+          <Plus className="h-4 w-4" />
+          {t('newBot')}
+        </Button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {bots.length === 0 && (
+          <p className="px-3 py-6 text-center text-xs text-muted-foreground">
+            No bots yet. A bot is a named agent you can keep messaging.
+          </p>
+        )}
+
+        {bots.map((bot) => (
+          <button
+            type="button"
+            key={bot.id}
+            onClick={() => select(bot)}
+            className={`flex w-full items-center gap-2 px-2 py-2 text-left hover:bg-accent/50 ${
+              selectedBotId === bot.id ? 'bg-accent' : ''
+            }`}
+          >
+            <BotAvatar bot={bot} running={Boolean(connectionByBot[bot.id])} />
+            <span className="min-w-0 flex-1">
+              <span className="flex items-baseline gap-2">
+                <span className="min-w-0 flex-1 truncate text-sm font-medium">{bot.name}</span>
+                <span className="shrink-0 text-[10px] text-muted-foreground">
+                  {since(bot.updatedAt)}
+                </span>
+              </span>
+              <span className="block truncate text-xs text-muted-foreground">
+                {bot.title || bot.model || bot.cwd || 'keke'}
+              </span>
+            </span>
+            {bot.unreadCount > 0 && (
+              <span className="shrink-0 rounded-full bg-primary px-1.5 text-[10px] text-primary-foreground">
+                {bot.unreadCount}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/bot/SideBarBotPane.tsx
+++ b/src/components/bot/SideBarBotPane.tsx
@@ -31,7 +31,7 @@ export function SideBarBotPane() {
   const { bots, setBots, upsertBot, selectedBotId, connectionByBot } = useBotUiStore();
   const setView = useLayoutStore((s) => s.setView);
   const cwd = useWorkspaceStore((s) => s.cwd);
-  const { open } = useBotSession();
+  const { open, openBlank } = useBotSession();
   const [newBot, setNewBot] = useState<Bot | null>(null);
 
   useEffect(() => {
@@ -51,13 +51,13 @@ export function SideBarBotPane() {
         cwd: cwd ?? '',
       });
       upsertBot(bot);
-      useBotUiStore.getState().setSelectedBotId(bot.id);
+      openBlank(bot);
       setView('bot');
       setNewBot(bot);
     } catch (e) {
       toast({ title: 'Could not create bot', description: String(e), variant: 'destructive' });
     }
-  }, [bots.length, cwd, setView, upsertBot]);
+  }, [bots.length, cwd, openBlank, setView, upsertBot]);
 
   const select = useCallback(
     (bot: Bot) => {

--- a/src/components/bot/SideBarBotPane.tsx
+++ b/src/components/bot/SideBarBotPane.tsx
@@ -1,5 +1,5 @@
 import { Plus } from 'lucide-react';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/components/ui/use-toast';
@@ -8,6 +8,7 @@ import { useLayoutStore } from '@/stores';
 import { useBotUiStore } from '@/stores/useBotUiStore';
 import { useWorkspaceStore } from '@/stores/useWorkspaceStore';
 import { BotAvatar } from './BotAvatar';
+import { BotSettingsDialog } from './BotSettingsDialog';
 import { defaultLook, newBotId } from './botDefaults';
 import { useBotSession } from './useBotSession';
 
@@ -31,6 +32,7 @@ export function SideBarBotPane() {
   const setView = useLayoutStore((s) => s.setView);
   const cwd = useWorkspaceStore((s) => s.cwd);
   const { open } = useBotSession();
+  const [newBot, setNewBot] = useState<Bot | null>(null);
 
   useEffect(() => {
     listBots()
@@ -51,6 +53,7 @@ export function SideBarBotPane() {
       upsertBot(bot);
       useBotUiStore.getState().setSelectedBotId(bot.id);
       setView('bot');
+      setNewBot(bot);
     } catch (e) {
       toast({ title: 'Could not create bot', description: String(e), variant: 'destructive' });
     }
@@ -109,6 +112,16 @@ export function SideBarBotPane() {
           </button>
         ))}
       </div>
+
+      {newBot && (
+        <BotSettingsDialog
+          bot={newBot}
+          open={Boolean(newBot)}
+          onOpenChange={(open) => {
+            if (!open) setNewBot(null);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/bot/SideBarBotPane.tsx
+++ b/src/components/bot/SideBarBotPane.tsx
@@ -1,4 +1,4 @@
-import { Plus } from 'lucide-react';
+import { Plus, SquarePen } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
@@ -8,6 +8,7 @@ import { useLayoutStore } from '@/stores';
 import { useBotUiStore } from '@/stores/useBotUiStore';
 import { useWorkspaceStore } from '@/stores/useWorkspaceStore';
 import { BotAvatar } from './BotAvatar';
+import { BotSessionList } from './BotSessionList';
 import { BotSettingsDialog } from './BotSettingsDialog';
 import { defaultLook, newBotId } from './botDefaults';
 import { useBotSession } from './useBotSession';
@@ -31,7 +32,7 @@ export function SideBarBotPane() {
   const { bots, setBots, upsertBot, selectedBotId, connectionByBot } = useBotUiStore();
   const setView = useLayoutStore((s) => s.setView);
   const cwd = useWorkspaceStore((s) => s.cwd);
-  const { open, openBlank } = useBotSession();
+  const { open, openBlank, startNew } = useBotSession();
   const [newBot, setNewBot] = useState<Bot | null>(null);
 
   useEffect(() => {
@@ -84,32 +85,52 @@ export function SideBarBotPane() {
         )}
 
         {bots.map((bot) => (
-          <button
-            type="button"
-            key={bot.id}
-            onClick={() => select(bot)}
-            className={`flex w-full items-center gap-2 px-2 py-2 text-left hover:bg-accent/50 ${
-              selectedBotId === bot.id ? 'bg-accent' : ''
-            }`}
-          >
-            <BotAvatar bot={bot} running={Boolean(connectionByBot[bot.id])} />
-            <span className="min-w-0 flex-1">
-              <span className="flex items-baseline gap-2">
-                <span className="min-w-0 flex-1 truncate text-sm font-medium">{bot.name}</span>
-                <span className="shrink-0 text-[10px] text-muted-foreground">
+          <div key={bot.id}>
+            <div
+              className={`group flex w-full items-center gap-2 px-2 py-2 hover:bg-accent/50 ${
+                selectedBotId === bot.id ? 'bg-accent' : ''
+              }`}
+            >
+              <button
+                type="button"
+                onClick={() => select(bot)}
+                className="flex min-w-0 flex-1 items-center gap-2 text-left"
+              >
+                <BotAvatar bot={bot} running={Boolean(connectionByBot[bot.id])} />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-medium">{bot.name}</span>
+                  <span className="block truncate text-xs text-muted-foreground">
+                    {bot.title || bot.model || bot.cwd || 'keke'}
+                  </span>
+                </span>
+                {bot.unreadCount > 0 && (
+                  <span className="shrink-0 rounded-full bg-primary px-1.5 text-[10px] text-primary-foreground">
+                    {bot.unreadCount}
+                  </span>
+                )}
+              </button>
+              <span className="relative flex h-6 w-6 shrink-0 items-center justify-center">
+                <span className="text-[10px] text-muted-foreground group-hover:hidden">
                   {since(bot.updatedAt)}
                 </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  title="New session"
+                  className="hidden group-hover:inline-flex"
+                  onClick={() => {
+                    setView('bot');
+                    void startNew(bot);
+                  }}
+                >
+                  <SquarePen />
+                </Button>
               </span>
-              <span className="block truncate text-xs text-muted-foreground">
-                {bot.title || bot.model || bot.cwd || 'keke'}
-              </span>
-            </span>
-            {bot.unreadCount > 0 && (
-              <span className="shrink-0 rounded-full bg-primary px-1.5 text-[10px] text-primary-foreground">
-                {bot.unreadCount}
-              </span>
-            )}
-          </button>
+            </div>
+
+            {selectedBotId === bot.id && <BotSessionList bot={bot} />}
+          </div>
         ))}
       </div>
 

--- a/src/components/bot/botAgentDef.ts
+++ b/src/components/bot/botAgentDef.ts
@@ -1,0 +1,58 @@
+import type { AcpAgentDef } from '@/services/apiAdapt/acp';
+import type { Bot, BotTrustLevel } from '@/services/apiAdapt/bots';
+
+/** How much a bot may do on its own, in keke's own vocabulary. */
+const TRUST: Record<BotTrustLevel, { approvalPolicy: string; sandboxMode: string }> = {
+  read_only: { approvalPolicy: 'on-request', sandboxMode: 'read_only' },
+  ask: { approvalPolicy: 'on-request', sandboxMode: 'workspace_write' },
+  autonomous: { approvalPolicy: 'never', sandboxMode: 'workspace_write' },
+};
+
+export function trustFor(bot: Bot) {
+  return TRUST[bot.trustLevel] ?? TRUST.ask;
+}
+
+export const TRUST_LEVELS: Array<{ id: BotTrustLevel; label: string; description: string }> = [
+  {
+    id: 'read_only',
+    label: 'Read-only',
+    description: 'Reads and answers. Cannot change files.',
+  },
+  { id: 'ask', label: 'Ask before writing', description: 'Asks before anything that writes.' },
+  {
+    id: 'autonomous',
+    label: 'Autonomous',
+    description: 'Works unattended in its own workspace.',
+  },
+];
+
+/**
+ * The process definition for one bot.
+ *
+ * keke has no notion of a named agent, so a bot's identity is handed over the
+ * two seams keke does have: spawn arguments, and `KEKE_INSTRUCTIONS`, which
+ * keke joins into the system prompt after its own identity and before the
+ * project's `AGENTS.md`.
+ *
+ * `keke` is the resolved `keke` preset from `acpListAgents` — its launcher
+ * (local binary, or the `npx` fallback) is reused as-is so a bot without a
+ * local install still runs, the same way the ACP composer's "Download & run"
+ * does.
+ */
+export function botAgentDef(bot: Bot, keke: AcpAgentDef): AcpAgentDef {
+  const args = [...keke.args];
+  if (bot.cwd) args.push('-C', bot.cwd);
+  if (bot.provider) args.push('--provider', bot.provider);
+
+  const env: Record<string, string> = { ...keke.env };
+  if (bot.systemPrompt?.trim()) env.KEKE_INSTRUCTIONS = bot.systemPrompt;
+
+  return {
+    id: `keke-bot-${bot.id}`,
+    name: bot.name,
+    command: keke.command,
+    args,
+    env,
+    available: keke.available,
+  };
+}

--- a/src/components/bot/botDefaults.ts
+++ b/src/components/bot/botDefaults.ts
@@ -1,0 +1,16 @@
+/** Avatars and colours a new bot is given, and the picker offers. */
+export const BOT_AVATARS = ['🤖', '🐣', '🦊', '🐙', '🦉', '🐝', '🚀', '📮', '🧭', '🧪'];
+
+export const BOT_COLORS = ['#2563eb', '#7c3aed', '#db2777', '#ea580c', '#16a34a', '#0891b2'];
+
+/** A distinct look per bot, so a new one is recognisable before it is renamed. */
+export function defaultLook(index: number) {
+  return {
+    avatar: BOT_AVATARS[index % BOT_AVATARS.length],
+    color: BOT_COLORS[index % BOT_COLORS.length],
+  };
+}
+
+export function newBotId() {
+  return `bot-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}

--- a/src/components/bot/index.ts
+++ b/src/components/bot/index.ts
@@ -1,0 +1,3 @@
+export { BotAvatar } from './BotAvatar';
+export { SideBarBotPane } from './SideBarBotPane';
+export { useBotSession } from './useBotSession';

--- a/src/components/bot/useBotDragDrop.ts
+++ b/src/components/bot/useBotDragDrop.ts
@@ -1,0 +1,33 @@
+import { getCurrentWebview } from '@tauri-apps/api/webview';
+import { stat } from '@tauri-apps/plugin-fs';
+import { useEffect } from 'react';
+import { type Bot, updateBot } from '@/services/apiAdapt/bots';
+import { useBotUiStore } from '@/stores/useBotUiStore';
+
+/** Dropping a folder (or a file) onto the bot's chat view sets its workspace. */
+export function useBotDragDrop(bot: Bot | undefined) {
+  const upsertBot = useBotUiStore((s) => s.upsertBot);
+  const botId = bot?.id;
+  const botCwd = bot?.cwd;
+
+  useEffect(() => {
+    if (!botId) return;
+    let cancelled = false;
+    const unlisten = getCurrentWebview().onDragDropEvent(async (event) => {
+      if (event.payload.type !== 'drop' || cancelled) return;
+      const [path] = event.payload.paths;
+      if (!path) return;
+
+      const info = await stat(path).catch(() => null);
+      const cwd = info?.isDirectory ? path : path.slice(0, path.lastIndexOf('/')) || path;
+      if (!cwd || cwd === botCwd) return;
+
+      upsertBot(await updateBot(botId, { cwd }));
+    });
+
+    return () => {
+      cancelled = true;
+      unlisten.then((fn) => fn());
+    };
+  }, [botId, botCwd, upsertBot]);
+}

--- a/src/components/bot/useBotSession.test.tsx
+++ b/src/components/bot/useBotSession.test.tsx
@@ -1,0 +1,232 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Bot } from '@/services/apiAdapt/bots';
+import { useAcpStore } from '@/stores/useAcpStore';
+import { useBotUiStore } from '@/stores/useBotUiStore';
+
+const acpStart = vi.fn();
+const acpGetSession = vi.fn();
+const listBotSessions = vi.fn();
+
+vi.mock('@/services/apiAdapt/acp', () => ({
+  acpStart: (...args: unknown[]) => acpStart(...args),
+  acpGetSession: (...args: unknown[]) => acpGetSession(...args),
+  acpSetConfigOption: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/services/apiAdapt/bots', () => ({
+  listBotSessions: (...args: unknown[]) => listBotSessions(...args),
+}));
+
+vi.mock('../acp/useAcpAgents', () => ({
+  loadAcpAgents: async () => [
+    { id: 'keke', name: 'keke', command: 'keke', args: [], env: {}, available: true, local: true },
+  ],
+}));
+
+vi.mock('@/stores/useBotOptionsStore', () => ({ captureBotOptions: vi.fn() }));
+vi.mock('@/components/ui/use-toast', () => ({ toast: vi.fn() }));
+
+import { useBotSession } from './useBotSession';
+
+function bot(id: string): Bot {
+  return {
+    id,
+    name: id,
+    title: null,
+    avatar: '',
+    color: '',
+    agentId: 'keke',
+    provider: null,
+    model: null,
+    reasoningEffort: null,
+    cwd: '/tmp',
+    systemPrompt: null,
+    trustLevel: 'ask',
+    approvedTools: '[]',
+    mcpServers: '[]',
+    pinned: false,
+    archived: false,
+    notificationsEnabled: true,
+    unreadCount: 0,
+    lastViewedAt: null,
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+/** A stored transcript entry, as the agent streams it. */
+const said = (text: string) => ({
+  sessionUpdate: 'agent_message_chunk',
+  content: { type: 'text', text },
+});
+
+const sessionRecord = (sessionId: string, botId: string) => ({
+  sessionId,
+  agentId: 'keke',
+  agentTitle: 'keke',
+  cwd: '/tmp',
+  botId,
+  title: null,
+  createdAt: '',
+  updatedAt: '',
+});
+
+/** The hook only wraps callbacks, so one render per test is enough. */
+const openBot = () => renderHook(() => useBotSession()).result.current.open;
+const hook = () => renderHook(() => useBotSession()).result.current;
+
+const texts = () =>
+  useAcpStore
+    .getState()
+    .entries.filter((e) => e.role !== 'tool')
+    .map((e) => e.text);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useAcpStore.getState().reset();
+  useBotUiStore.setState({
+    bots: [],
+    selectedBotId: null,
+    connectionByBot: {},
+    sessionByBot: {},
+    runningByBot: {},
+    kekeSpawnFailed: false,
+  });
+});
+
+describe('useBotSession.open', () => {
+  it('replays the last transcript that has messages, not the empty session a restart left behind', async () => {
+    // What a restarted app sees: this run's fresh session, the empty session
+    // the previous run opened, and before that the real conversation.
+    acpStart.mockResolvedValue({
+      connectionId: 'c-new',
+      sessionId: 's-new',
+      initialize: {},
+      session: { sessionId: 's-new' },
+      sessionError: null,
+    });
+    listBotSessions.mockResolvedValue([
+      sessionRecord('s-new', 'bot1'),
+      sessionRecord('s-empty', 'bot1'),
+      sessionRecord('s-old', 'bot1'),
+    ]);
+    acpGetSession.mockImplementation(async (id: string) =>
+      id === 's-old' ? [said('from before the restart')] : []
+    );
+
+    const open = openBot();
+    await open(bot('bot1'));
+
+    expect(texts()).toEqual(['from before the restart']);
+  });
+
+  it('does not pour a slow bot\'s history into the bot the user switched to', async () => {
+    acpStart.mockImplementation(async (_agentId, _cwd, _def, botId: string) => ({
+      connectionId: `c-${botId}`,
+      sessionId: `s-${botId}`,
+      initialize: {},
+      session: { sessionId: `s-${botId}` },
+      sessionError: null,
+    }));
+    listBotSessions.mockImplementation(async (botId: string) => [
+      sessionRecord(`s-${botId}`, botId),
+      sessionRecord(`old-${botId}`, botId),
+    ]);
+
+    // bot1's transcript resolves only after bot2 has been opened.
+    let releaseBot1: () => void = () => {};
+    const bot1Loaded = new Promise<void>((resolve) => {
+      releaseBot1 = resolve;
+    });
+    acpGetSession.mockImplementation(async (id: string) => {
+      if (id === 'old-bot1') {
+        await bot1Loaded;
+        return [said('bot1 history')];
+      }
+      if (id === 'old-bot2') return [said('bot2 history')];
+      return [];
+    });
+
+    const open = openBot();
+    const first = open(bot('bot1'));
+    await open(bot('bot2'));
+    releaseBot1();
+    await first;
+
+    expect(useBotUiStore.getState().selectedBotId).toBe('bot2');
+    expect(texts()).toEqual(['bot2 history']);
+    // bot1's process is still remembered, it just did not render.
+    expect(useBotUiStore.getState().connectionByBot.bot1).toBe('c-bot1');
+  });
+
+  it('restores a bot that is already connected without spawning again', async () => {
+    useBotUiStore.setState({
+      connectionByBot: { bot1: 'c-1' },
+      sessionByBot: { bot1: 's-1' },
+    });
+    acpGetSession.mockImplementation(async (id: string) =>
+      id === 's-1' ? [said('still here')] : []
+    );
+
+    const open = openBot();
+    await open(bot('bot1'));
+
+    expect(acpStart).not.toHaveBeenCalled();
+    expect(texts()).toEqual(['still here']);
+  });
+  it('keeps history and this run\'s messages when switching away and back', async () => {
+    acpStart.mockImplementation(async (_agentId, _cwd, _def, botId: string) => ({
+      connectionId: `c-${botId}`,
+      sessionId: `s-${botId}`,
+      initialize: {},
+      session: { sessionId: `s-${botId}` },
+      sessionError: null,
+    }));
+    listBotSessions.mockImplementation(async (botId: string) => [
+      sessionRecord(`s-${botId}`, botId),
+      sessionRecord(`old-${botId}`, botId),
+    ]);
+    const live: Record<string, unknown[]> = {
+      's-bot1': [],
+      's-bot2': [],
+      'old-bot1': [said('before the restart')],
+      'old-bot2': [],
+    };
+    acpGetSession.mockImplementation(async (id: string) => live[id] ?? []);
+
+    const open = openBot();
+    await open(bot('bot1'));
+    // A turn taken in this run lands in the fresh session.
+    live['s-bot1'] = [said('after the restart')];
+
+    await open(bot('bot2'));
+    await open(bot('bot1'));
+
+    expect(texts()).toEqual(['before the restart', 'after the restart']);
+  });
+
+  it('shows an empty pane for a bot that was just created', async () => {
+    acpStart.mockResolvedValue({
+      connectionId: 'c-1',
+      sessionId: 's-1',
+      initialize: {},
+      session: { sessionId: 's-1' },
+      sessionError: null,
+    });
+    listBotSessions.mockResolvedValue([sessionRecord('old-bot1', 'bot1')]);
+    acpGetSession.mockImplementation(async (id: string) =>
+      id === 'old-bot1' ? [said('bot1 was talking')] : []
+    );
+
+    const { open, openBlank } = hook();
+    await open(bot('bot1'));
+    expect(texts()).toEqual(['bot1 was talking']);
+
+    // Creating a bot does not start it, so nothing clears the pane but this.
+    openBlank(bot('bot2'));
+
+    expect(texts()).toEqual([]);
+    expect(useBotUiStore.getState().selectedBotId).toBe('bot2');
+  });
+});

--- a/src/components/bot/useBotSession.ts
+++ b/src/components/bot/useBotSession.ts
@@ -4,6 +4,7 @@ import { acpGetSession, acpSetConfigOption, acpStart } from '@/services/apiAdapt
 import type { Bot } from '@/services/apiAdapt/bots';
 import { listBotSessions } from '@/services/apiAdapt/bots';
 import { useAcpStore } from '@/stores/useAcpStore';
+import { captureBotOptions } from '@/stores/useBotOptionsStore';
 import { useBotUiStore } from '@/stores/useBotUiStore';
 import { applyAcpUpdate } from '../acp/applyUpdate';
 import { loadAcpAgents } from '../acp/useAcpAgents';
@@ -89,6 +90,9 @@ export function useBotSession() {
           canLoadSession: res.initialize.agentCapabilities?.loadSession === true,
         });
         store.applySession(res.session);
+        // Remember what keke offers, so a bot that has never run can still be
+        // configured from a list rather than typed-in provider/model strings.
+        captureBotOptions(res.initialize, res.session);
         ui.setBotConnection(bot.id, res.connectionId);
 
         if (res.sessionError || !res.sessionId) {

--- a/src/components/bot/useBotSession.ts
+++ b/src/components/bot/useBotSession.ts
@@ -11,6 +11,48 @@ import { loadAcpAgents } from '../acp/useAcpAgents';
 import { botAgentDef, trustFor } from './botAgentDef';
 
 /**
+ * Everything a bot's pane should show: the last conversation it had before
+ * `currentSessionId` was opened, followed by that session's own updates.
+ *
+ * A bot gets a fresh session on every app restart, so the newest stored record
+ * is regularly an empty one — the history is the newest *other* session that
+ * actually holds updates, and it stays on screen once the current session
+ * starts filling up, which is what makes the thread read as continuous across
+ * restarts and across switching bots.
+ */
+async function loadTranscript(botId: string, currentSessionId?: string) {
+  const stored = await listBotSessions(botId).catch(() => []);
+  let history: unknown[] = [];
+  for (const record of stored) {
+    if (record.sessionId === currentSessionId) continue;
+    const updates = await acpGetSession(record.sessionId).catch(() => []);
+    if (updates.length > 0) {
+      history = updates;
+      break;
+    }
+  }
+  const current = currentSessionId ? await acpGetSession(currentSessionId).catch(() => []) : [];
+  return { history, current };
+}
+
+/**
+ * Replay a transcript into the ACP store, but only while `botId` is still the
+ * open bot: these loads are async, and a bot switched away from mid-load must
+ * not pour its history into the bot now on screen.
+ */
+function replayInto(
+  botId: string,
+  { history, current }: Awaited<ReturnType<typeof loadTranscript>>
+) {
+  if (useBotUiStore.getState().selectedBotId !== botId) return;
+  for (const update of history) applyAcpUpdate(update as Record<string, any>);
+  // The two transcripts are different turns, so the last message of one must
+  // not merge into the first of the other.
+  if (history.length > 0 && current.length > 0) useAcpStore.getState().sealChunk();
+  for (const update of current) applyAcpUpdate(update as Record<string, any>);
+}
+
+/**
  * Opening a bot's conversation.
  *
  * A bot is its own long-lived keke process: the connection is kept in
@@ -49,6 +91,11 @@ export function useBotSession() {
       ui.setSelectedBotId(bot.id);
       store.setAgentId(bot.agentId);
 
+      // Opening is async and the ACP store holds exactly one conversation, so
+      // every write to it after an await has to check that this bot is still
+      // the one on screen — otherwise a slow bot lands in a faster one's pane.
+      const stale = () => useBotUiStore.getState().selectedBotId !== bot.id;
+
       const existing = ui.connectionByBot[bot.id];
       const existingSession = ui.sessionByBot[bot.id];
       if (existing && existingSession) {
@@ -61,9 +108,7 @@ export function useBotSession() {
           canLoadSession: store.canLoadSession,
         });
         store.setEntries([]);
-        for (const update of await acpGetSession(existingSession)) {
-          applyAcpUpdate(update as Record<string, any>);
-        }
+        replayInto(bot.id, await loadTranscript(bot.id, existingSession));
         return { connectionId: existing, sessionId: existingSession };
       }
 
@@ -82,6 +127,14 @@ export function useBotSession() {
       store.setEntries([]);
       try {
         const res = await acpStart(bot.agentId, bot.cwd, botAgentDef(bot, keke), bot.id);
+        if (res.connectionId) ui.setBotConnection(bot.id, res.connectionId);
+        if (res.sessionId) ui.setBotSession(bot.id, res.sessionId);
+        if (stale()) {
+          if (res.sessionId) await applySettings(bot, res.connectionId, res.sessionId);
+          return res.sessionId
+            ? { connectionId: res.connectionId, sessionId: res.sessionId }
+            : null;
+        }
         store.setConnection({
           connectionId: res.connectionId,
           sessionId: res.sessionId,
@@ -93,7 +146,6 @@ export function useBotSession() {
         // Remember what keke offers, so a bot that has never run can still be
         // configured from a list rather than typed-in provider/model strings.
         captureBotOptions(res.initialize, res.session);
-        ui.setBotConnection(bot.id, res.connectionId);
 
         if (res.sessionError || !res.sessionId) {
           store.addEntry({
@@ -103,20 +155,13 @@ export function useBotSession() {
           });
           return null;
         }
-        ui.setBotSession(bot.id, res.sessionId);
         ui.setKekeSpawnFailed(false);
         await applySettings(bot, res.connectionId, res.sessionId);
 
         // A bot that has talked before gets its last conversation back, so the
         // chat reads as one continuous thread rather than restarting each time
         // the app does. keke's own session is new; the transcript is history.
-        const stored = await listBotSessions(bot.id).catch(() => []);
-        const previous = stored.find((record) => record.sessionId !== res.sessionId);
-        if (previous) {
-          for (const update of await acpGetSession(previous.sessionId)) {
-            applyAcpUpdate(update as Record<string, any>);
-          }
-        }
+        replayInto(bot.id, await loadTranscript(bot.id, res.sessionId));
 
         return { connectionId: res.connectionId, sessionId: res.sessionId };
       } catch (e) {
@@ -135,11 +180,22 @@ export function useBotSession() {
         }
         return null;
       } finally {
-        store.setConnecting(false);
+        if (!stale()) store.setConnecting(false);
       }
     },
     [applySettings]
   );
 
-  return { open, applySettings };
+  /**
+   * Show a bot that has nothing to show yet — a freshly created one. Creating a
+   * bot never starts its process, so without this the pane would keep
+   * rendering the previous bot's conversation, which the ACP store still holds.
+   */
+  const openBlank = useCallback((bot: Bot) => {
+    useAcpStore.getState().reset();
+    useAcpStore.getState().setAgentId(bot.agentId);
+    useBotUiStore.getState().setSelectedBotId(bot.id);
+  }, []);
+
+  return { open, openBlank, applySettings };
 }

--- a/src/components/bot/useBotSession.ts
+++ b/src/components/bot/useBotSession.ts
@@ -1,12 +1,20 @@
 import { useCallback } from 'react';
 import { toast } from '@/components/ui/use-toast';
-import { acpGetSession, acpSetConfigOption, acpStart } from '@/services/apiAdapt/acp';
+import {
+  type AcpSessionRecord,
+  acpGetSession,
+  acpLoadSession,
+  acpNewSession,
+  acpSetConfigOption,
+  acpStart,
+} from '@/services/apiAdapt/acp';
 import type { Bot } from '@/services/apiAdapt/bots';
 import { listBotSessions } from '@/services/apiAdapt/bots';
 import { useAcpStore } from '@/stores/useAcpStore';
 import { captureBotOptions } from '@/stores/useBotOptionsStore';
 import { useBotUiStore } from '@/stores/useBotUiStore';
 import { applyAcpUpdate } from '../acp/applyUpdate';
+import { acpFreshSession } from '../acp/newSession';
 import { loadAcpAgents } from '../acp/useAcpAgents';
 import { botAgentDef, trustFor } from './botAgentDef';
 
@@ -20,7 +28,7 @@ import { botAgentDef, trustFor } from './botAgentDef';
  * starts filling up, which is what makes the thread read as continuous across
  * restarts and across switching bots.
  */
-async function loadTranscript(botId: string, currentSessionId?: string) {
+async function loadTranscript(botId: string, currentSessionId?: string, includeCurrent = true) {
   const stored = await listBotSessions(botId).catch(() => []);
   let history: unknown[] = [];
   for (const record of stored) {
@@ -31,7 +39,8 @@ async function loadTranscript(botId: string, currentSessionId?: string) {
       break;
     }
   }
-  const current = currentSessionId ? await acpGetSession(currentSessionId).catch(() => []) : [];
+  const current =
+    includeCurrent && currentSessionId ? await acpGetSession(currentSessionId).catch(() => []) : [];
   return { history, current };
 }
 
@@ -84,7 +93,7 @@ export function useBotSession() {
    * live ids, or null when the bot could not be opened.
    */
   const open = useCallback(
-    async (bot: Bot) => {
+    async (bot: Bot, requestedSession?: AcpSessionRecord) => {
       const ui = useBotUiStore.getState();
       const store = useAcpStore.getState();
 
@@ -99,17 +108,40 @@ export function useBotSession() {
       const existing = ui.connectionByBot[bot.id];
       const existingSession = ui.sessionByBot[bot.id];
       if (existing && existingSession) {
-        // The process is still ours; only the pane has to catch up.
+        // The process is still ours; only the pane has to catch up. Selecting a
+        // session from the bot's history either resumes it or replays it into a
+        // fresh agent-side session when the agent cannot load sessions.
+        let activeSessionId = existingSession;
         store.setConnection({
           connectionId: existing,
-          sessionId: existingSession,
+          sessionId: activeSessionId,
           agentTitle: bot.name,
           authMethods: [],
           canLoadSession: store.canLoadSession,
         });
         store.setEntries([]);
-        replayInto(bot.id, await loadTranscript(bot.id, existingSession));
-        return { connectionId: existing, sessionId: existingSession };
+        if (requestedSession && requestedSession.sessionId !== existingSession) {
+          if (store.canLoadSession) {
+            store.setSessionId(requestedSession.sessionId);
+            store.applySession({
+              ...(await acpLoadSession(existing, requestedSession.sessionId, requestedSession.cwd)),
+              sessionId: requestedSession.sessionId,
+            });
+            activeSessionId = requestedSession.sessionId;
+          } else {
+            const session = await acpNewSession(existing, bot.cwd);
+            store.applySession(session);
+            activeSessionId = session.sessionId;
+          }
+          ui.setBotSession(bot.id, activeSessionId);
+          replayInto(bot.id, {
+            history: [],
+            current: await acpGetSession(requestedSession.sessionId).catch(() => []),
+          });
+        } else {
+          replayInto(bot.id, await loadTranscript(bot.id, activeSessionId));
+        }
+        return { connectionId: existing, sessionId: activeSessionId };
       }
 
       // Neither a local `keke` nor `npx` resolved: there is nothing to spawn.
@@ -135,14 +167,33 @@ export function useBotSession() {
             ? { connectionId: res.connectionId, sessionId: res.sessionId }
             : null;
         }
+        const canLoadSession = res.initialize.agentCapabilities?.loadSession === true;
+        const sessionToRestore =
+          requestedSession ?? (await listBotSessions(bot.id).catch(() => []))[0];
+        const restoreStoredSession = sessionToRestore && canLoadSession;
+        const activeSessionId = restoreStoredSession ? sessionToRestore.sessionId : res.sessionId;
+
         store.setConnection({
           connectionId: res.connectionId,
-          sessionId: res.sessionId,
+          sessionId: activeSessionId,
           agentTitle: bot.name,
           authMethods: res.initialize.authMethods ?? [],
-          canLoadSession: res.initialize.agentCapabilities?.loadSession === true,
+          canLoadSession,
         });
-        store.applySession(res.session);
+        if (restoreStoredSession) {
+          store.setEntries([]);
+          store.applySession({
+            ...(await acpLoadSession(
+              res.connectionId,
+              sessionToRestore.sessionId,
+              sessionToRestore.cwd
+            )),
+            sessionId: sessionToRestore.sessionId,
+          });
+          ui.setBotSession(bot.id, sessionToRestore.sessionId);
+        } else {
+          store.applySession(res.session);
+        }
         // Remember what keke offers, so a bot that has never run can still be
         // configured from a list rather than typed-in provider/model strings.
         captureBotOptions(res.initialize, res.session);
@@ -158,12 +209,24 @@ export function useBotSession() {
         ui.setKekeSpawnFailed(false);
         await applySettings(bot, res.connectionId, res.sessionId);
 
-        // A bot that has talked before gets its last conversation back, so the
-        // chat reads as one continuous thread rather than restarting each time
-        // the app does. keke's own session is new; the transcript is history.
-        replayInto(bot.id, await loadTranscript(bot.id, res.sessionId));
+        // Agents that support `session/load` resume the exact selected thread.
+        // For other agents, the stored transcript remains read-only history and
+        // prompts go to the fresh session this process opened.
+        if (requestedSession && !restoreStoredSession) {
+          replayInto(bot.id, {
+            history: [],
+            current: await acpGetSession(requestedSession.sessionId).catch(() => []),
+          });
+        } else {
+          replayInto(
+            bot.id,
+            await loadTranscript(bot.id, activeSessionId ?? undefined, !restoreStoredSession)
+          );
+        }
 
-        return { connectionId: res.connectionId, sessionId: res.sessionId };
+        return activeSessionId
+          ? { connectionId: res.connectionId, sessionId: activeSessionId }
+          : null;
       } catch (e) {
         // `available` said keke would run — a packaged app's PATH not
         // matching the shell's is the usual reason it didn't anyway. Once
@@ -197,5 +260,41 @@ export function useBotSession() {
     useBotUiStore.getState().setSelectedBotId(bot.id);
   }, []);
 
-  return { open, openBlank, applySettings };
+  /** Start a blank conversation on this bot, keeping its process if it is live. */
+  const startNew = useCallback(
+    async (bot: Bot) => {
+      const ui = useBotUiStore.getState();
+      const existing = ui.connectionByBot[bot.id];
+      if (existing) {
+        ui.setSelectedBotId(bot.id);
+        useAcpStore.getState().setAgentId(bot.agentId);
+        useAcpStore.getState().setConnection({
+          connectionId: existing,
+          sessionId: ui.sessionByBot[bot.id] ?? '',
+          agentTitle: bot.name,
+          authMethods: [],
+          canLoadSession: useAcpStore.getState().canLoadSession,
+        });
+        const ok = await acpFreshSession(existing, bot.cwd);
+        const sessionId = useAcpStore.getState().sessionId;
+        if (ok && sessionId) {
+          ui.setBotSession(bot.id, sessionId);
+          await applySettings(bot, existing, sessionId);
+        }
+        return;
+      }
+
+      const opened = await open(bot);
+      if (!opened) return;
+      const ok = await acpFreshSession(opened.connectionId, bot.cwd);
+      const sessionId = useAcpStore.getState().sessionId;
+      if (ok && sessionId) {
+        useBotUiStore.getState().setBotSession(bot.id, sessionId);
+        await applySettings(bot, opened.connectionId, sessionId);
+      }
+    },
+    [applySettings, open]
+  );
+
+  return { open, openBlank, startNew, applySettings };
 }

--- a/src/components/bot/useBotSession.ts
+++ b/src/components/bot/useBotSession.ts
@@ -1,0 +1,141 @@
+import { useCallback } from 'react';
+import { toast } from '@/components/ui/use-toast';
+import { acpGetSession, acpSetConfigOption, acpStart } from '@/services/apiAdapt/acp';
+import type { Bot } from '@/services/apiAdapt/bots';
+import { listBotSessions } from '@/services/apiAdapt/bots';
+import { useAcpStore } from '@/stores/useAcpStore';
+import { useBotUiStore } from '@/stores/useBotUiStore';
+import { applyAcpUpdate } from '../acp/applyUpdate';
+import { loadAcpAgents } from '../acp/useAcpAgents';
+import { botAgentDef, trustFor } from './botAgentDef';
+
+/**
+ * Opening a bot's conversation.
+ *
+ * A bot is its own long-lived keke process: the connection is kept in
+ * `useBotUiStore` so coming back to a bot costs nothing, and only the very
+ * first message pays for a spawn. Nothing here runs while the sidebar merely
+ * lists bots — that read is deliberately cold.
+ */
+export function useBotSession() {
+  /** Apply the bot's own settings to a session keke has just opened. */
+  const applySettings = useCallback(async (bot: Bot, connectionId: string, sessionId: string) => {
+    const trust = trustFor(bot);
+    const options: Array<[string, string]> = [['approval_policy', trust.approvalPolicy]];
+    if (bot.model) options.push(['model', bot.model]);
+    if (bot.reasoningEffort) options.push(['reasoning_effort', bot.reasoningEffort]);
+
+    for (const [id, value] of options) {
+      // An agent that does not offer one of these says so per option; that is
+      // not a reason to abandon the rest of the bot's settings.
+      try {
+        await acpSetConfigOption(connectionId, sessionId, id, value);
+      } catch (e) {
+        console.warn(`bot: ${bot.name} could not set ${id}`, e);
+      }
+    }
+  }, []);
+
+  /**
+   * Show a bot's conversation, starting its process if it has none. Returns the
+   * live ids, or null when the bot could not be opened.
+   */
+  const open = useCallback(
+    async (bot: Bot) => {
+      const ui = useBotUiStore.getState();
+      const store = useAcpStore.getState();
+
+      ui.setSelectedBotId(bot.id);
+      store.setAgentId(bot.agentId);
+
+      const existing = ui.connectionByBot[bot.id];
+      const existingSession = ui.sessionByBot[bot.id];
+      if (existing && existingSession) {
+        // The process is still ours; only the pane has to catch up.
+        store.setConnection({
+          connectionId: existing,
+          sessionId: existingSession,
+          agentTitle: bot.name,
+          authMethods: [],
+          canLoadSession: store.canLoadSession,
+        });
+        store.setEntries([]);
+        for (const update of await acpGetSession(existingSession)) {
+          applyAcpUpdate(update as Record<string, any>);
+        }
+        return { connectionId: existing, sessionId: existingSession };
+      }
+
+      // Neither a local `keke` nor `npx` resolved: there is nothing to spawn.
+      // The composer shows an install prompt for this instead of a toast.
+      // Awaited fresh rather than read off `useAcpAgents`' hook state, which
+      // can still be the pre-fetch empty array on a component's first render.
+      const keke = (await loadAcpAgents()).find((a) => a.id === 'keke');
+      console.log('bot: opening', bot.name, 'with keke', keke);
+      if (!keke || !keke.local) {
+        store.setEntries([]);
+        return null;
+      }
+
+      store.setConnecting(true);
+      store.setEntries([]);
+      try {
+        const res = await acpStart(bot.agentId, bot.cwd, botAgentDef(bot, keke), bot.id);
+        store.setConnection({
+          connectionId: res.connectionId,
+          sessionId: res.sessionId,
+          agentTitle: bot.name,
+          authMethods: res.initialize.authMethods ?? [],
+          canLoadSession: res.initialize.agentCapabilities?.loadSession === true,
+        });
+        store.applySession(res.session);
+        ui.setBotConnection(bot.id, res.connectionId);
+
+        if (res.sessionError || !res.sessionId) {
+          store.addEntry({
+            id: `start-${Date.now()}`,
+            role: 'error',
+            text: res.sessionError ?? 'keke opened no session.',
+          });
+          return null;
+        }
+        ui.setBotSession(bot.id, res.sessionId);
+        ui.setKekeSpawnFailed(false);
+        await applySettings(bot, res.connectionId, res.sessionId);
+
+        // A bot that has talked before gets its last conversation back, so the
+        // chat reads as one continuous thread rather than restarting each time
+        // the app does. keke's own session is new; the transcript is history.
+        const stored = await listBotSessions(bot.id).catch(() => []);
+        const previous = stored.find((record) => record.sessionId !== res.sessionId);
+        if (previous) {
+          for (const update of await acpGetSession(previous.sessionId)) {
+            applyAcpUpdate(update as Record<string, any>);
+          }
+        }
+
+        return { connectionId: res.connectionId, sessionId: res.sessionId };
+      } catch (e) {
+        // `available` said keke would run — a packaged app's PATH not
+        // matching the shell's is the usual reason it didn't anyway. Once
+        // that happens, show the install prompt instead of retrying and
+        // toasting on every message.
+        if (/failed to spawn|no such file|not found|enoent/i.test(String(e))) {
+          ui.setKekeSpawnFailed(true);
+        } else {
+          toast({
+            title: `Could not start ${bot.name}`,
+            description: String(e),
+            variant: 'destructive',
+          });
+        }
+        return null;
+      } finally {
+        store.setConnecting(false);
+      }
+    },
+    [applySettings]
+  );
+
+  return { open, applySettings };
+}

--- a/src/components/bot/useBotSettingsForm.ts
+++ b/src/components/bot/useBotSettingsForm.ts
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+import { type Bot, type BotTrustLevel, parseBotList } from '@/services/apiAdapt/bots';
+
+/**
+ * The editable copy of a bot's settings. Reopening the dialog on another bot
+ * must not show the previous one's draft, so the form is reset whenever the
+ * dialog opens or the bot behind it changes.
+ */
+export function useBotSettingsForm(bot: Bot, open: boolean) {
+  const [name, setName] = useState(bot.name);
+  const [title, setTitle] = useState(bot.title ?? '');
+  const [avatar, setAvatar] = useState(bot.avatar);
+  const [color, setColor] = useState(bot.color);
+  const [cwd, setCwd] = useState(bot.cwd);
+  const [provider, setProvider] = useState(bot.provider ?? '');
+  const [model, setModel] = useState(bot.model ?? '');
+  const [reasoningEffort, setReasoningEffort] = useState(bot.reasoningEffort ?? '');
+  const [systemPrompt, setSystemPrompt] = useState(bot.systemPrompt ?? '');
+  const [trustLevel, setTrustLevel] = useState<BotTrustLevel>(bot.trustLevel);
+  const [approvedTools, setApprovedTools] = useState(parseBotList(bot.approvedTools));
+
+  useEffect(() => {
+    if (!open) return;
+    setName(bot.name);
+    setTitle(bot.title ?? '');
+    setAvatar(bot.avatar);
+    setColor(bot.color);
+    setCwd(bot.cwd);
+    setProvider(bot.provider ?? '');
+    setModel(bot.model ?? '');
+    setReasoningEffort(bot.reasoningEffort ?? '');
+    setSystemPrompt(bot.systemPrompt ?? '');
+    setTrustLevel(bot.trustLevel);
+    setApprovedTools(parseBotList(bot.approvedTools));
+  }, [open, bot]);
+
+  return {
+    name,
+    setName,
+    title,
+    setTitle,
+    avatar,
+    setAvatar,
+    color,
+    setColor,
+    cwd,
+    setCwd,
+    provider,
+    setProvider,
+    model,
+    setModel,
+    reasoningEffort,
+    setReasoningEffort,
+    systemPrompt,
+    setSystemPrompt,
+    trustLevel,
+    setTrustLevel,
+    approvedTools,
+    setApprovedTools,
+    /** The patch `updateBot` takes, with the bot's own name kept if cleared. */
+    patch: {
+      name: name.trim() || bot.name,
+      title,
+      avatar,
+      color,
+      cwd,
+      provider,
+      model,
+      reasoningEffort,
+      systemPrompt,
+      trustLevel,
+      approvedTools,
+    },
+  };
+}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -15,6 +15,7 @@ const AutoMationsView = lazy(() =>
   import('../../features/automations').then((module) => ({ default: module.AutoMationsView }))
 );
 const InsightsView = lazy(() => import('@/features/insight/InsightsView'));
+const BotChatView = lazy(() => import('@/components/bot/BotChatView'));
 
 // Inner component so it can call useSidebar() inside SidebarProvider
 const MIN_RIGHT_PANEL_SIZE = 22;
@@ -183,6 +184,7 @@ export function AppLayout() {
           {view === 'automations' && <AutoMationsView />}
           {view === 'plugins' && <PluginsView />}
           {view === 'insights' && <InsightsView />}
+          {view === 'bot' && <BotChatView />}
         </Suspense>
       </div>
     </div>

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -1,17 +1,9 @@
-import { BarChart2, Bug, ListFilter, Monitor, Package2, Search, Timer } from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { Bug, Monitor, Search } from 'lucide-react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { AgentSwitcher } from '@/components/agent';
-import { useNewThread, useThreadList } from '@/components/codex/hooks';
+import { SideBarBotPane } from '@/components/bot';
 import { DesktopDrawer } from '@/components/pairing/DesktopDrawer';
 import { Button } from '@/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import {
   Sidebar,
   SidebarContent,
@@ -22,77 +14,33 @@ import {
 } from '@/components/ui/sidebar';
 import { useTrafficLightConfig } from '@/hooks';
 import { isPhone } from '@/hooks/runtime';
-import { useCCSessionManager } from '@/hooks/useCCSessionManager';
-import { useLayoutStore } from '@/stores';
-import { useAcpStore } from '@/stores/useAcpStore';
-import { useAgentSettingsStore } from '@/stores/useAgentSettingsStore';
-import { useWorkspaceStore } from '@/stores/useWorkspaceStore';
+import { type SidebarMode, useLayoutStore } from '@/stores';
 import { UpdateIndicator } from '../../features/UpdateIndicator';
-import { NewAgentButton } from '../common/NewAgentButton';
 import { SessionManagerDialog } from '../common/SessionManagerDialog';
-import { SideBarAddProjectButton } from './SideBarAddProjectButton';
-import { SideBarPinnedList } from './SideBarPinnedList';
-import { SideBarAcpTab, SideBarClaudeTab, SideBarCodexTab } from './SideBarTab';
+import { SideBarAgentHeader, SideBarAgentList } from './SideBarAgentPane';
 import { UserInfo } from './UserInfo';
-
-const focusCCInput = () => window.dispatchEvent(new Event('cc-input-focus-request'));
-
-// Shared class for nav buttons (Automations / Marketplace)
-const navBtnBase = 'justify-start gap-2 rounded-md border px-2.5';
-const navBtnActive = 'border-border bg-accent/70 text-accent-foreground';
-const navBtnInactive = 'border-transparent hover:border-border/60';
-const navBtnCls = (active: boolean) => `${navBtnBase} ${active ? navBtnActive : navBtnInactive}`;
 
 export function AppSideBar() {
   const { t } = useTranslation('sidebar');
-  const { cwd, setCwd } = useWorkspaceStore();
-  const { setSelectedAgent, selectedAgent } = useAgentSettingsStore();
-  const acpActive = useAcpStore((s) => s.active);
-  const { setView, view, activeSidebarTab, setActiveSidebarTab } = useLayoutStore();
+  const modes: Array<{ id: SidebarMode; label: string }> = [
+    { id: 'agent', label: t('agent') },
+    { id: 'bot', label: t('bot') },
+  ];
+  const { view, setView, activeSidebarTab, sidebarMode, setSidebarMode } = useLayoutStore();
   const { open: isSidebarOpen } = useSidebar();
   const { isMacos } = useTrafficLightConfig(isSidebarOpen);
-  const { sortKey, setSortKey } = useThreadList({
-    enabled: isSidebarOpen && selectedAgent === 'codex',
-  });
-  const { handleNewThread } = useNewThread();
-  const { handleNewSession } = useCCSessionManager();
   const [sessionManagerOpen, setSessionManagerOpen] = useState(false);
   // Only a phone drives a remote machine; a desktop is its own backend and has
   // nothing to switch between.
   const [desktopDrawerOpen, setDesktopDrawerOpen] = useState(false);
 
-  const currentThreadSortLabel = sortKey === 'created_at' ? 'Created' : 'Updated';
-
-  const handleCreateNewThreadForProject = useCallback(
-    (project: string) => {
-      if (project !== cwd) setCwd(project);
-      void handleNewThread();
-    },
-    [cwd, handleNewThread, setCwd]
-  );
-
-  const handleStartNewAcpSessionForProject = useCallback(
-    (directory: string) => {
-      setView('agent');
-      setCwd(directory);
-      // `restart` tears down the connection and asks the composer to reconnect
-      // in the new workspace.
-      useAcpStore.getState().restart();
-    },
-    [setCwd, setView]
-  );
-
-  const handleStartNewCcSessionForProject = useCallback(
-    async (directory: string) => {
-      setSelectedAgent('cc');
-      setActiveSidebarTab('cc');
-      setView('agent');
-      setCwd(directory);
-      await handleNewSession();
-      focusCCInput();
-    },
-    [handleNewSession, setActiveSidebarTab, setCwd, setSelectedAgent, setView]
-  );
+  const selectMode = (mode: SidebarMode) => {
+    setSidebarMode(mode);
+    // The Bot tab is a conversation, not a workspace: switching to it leaves
+    // the agent views behind rather than showing an empty one beside them.
+    if (mode === 'bot') setView('bot');
+    else if (view === 'bot') setView('agent');
+  };
 
   return (
     <>
@@ -126,86 +74,29 @@ export function AppSideBar() {
             )}
           </div>
 
-          {/* Nav actions */}
-          <div className="flex flex-col">
-            <NewAgentButton showLabel />
-            <Button
-              variant="ghost"
-              size="sm"
-              className={navBtnCls(view === 'plugins')}
-              onClick={() => setView('plugins')}
-            >
-              <Package2 className="h-4 w-4" />
-              {t('plugins')}
-            </Button>
-
-            <Button
-              variant="ghost"
-              size="sm"
-              className={navBtnCls(view === 'automations')}
-              onClick={() => setView('automations')}
-            >
-              <Timer className="h-4 w-4" />
-              {t('automations')}
-            </Button>
-
-            <Button
-              variant="ghost"
-              size="sm"
-              className={navBtnCls(view === 'insights')}
-              onClick={() => setView('insights')}
-            >
-              <BarChart2 className="h-4 w-4" />
-              {t('insights')}
-            </Button>
-
-            <SideBarPinnedList />
+          {/* Agent / Bot */}
+          <div className="flex items-center gap-1 rounded-md bg-muted/50 p-0.5">
+            {modes.map((mode) => (
+              <button
+                type="button"
+                key={mode.id}
+                onClick={() => selectMode(mode.id)}
+                className={`flex-1 rounded-[5px] px-2 py-1 text-xs font-medium transition-colors ${
+                  sidebarMode === mode.id
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {mode.label}
+              </button>
+            ))}
           </div>
 
-          {/* Tab switcher row */}
-          <span className="flex justify-between">
-            <AgentSwitcher className="flex gap-2" />
-
-            <span className="flex gap-2">
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8"
-                    title={`Filter threads (current: ${currentThreadSortLabel})`}
-                  >
-                    <ListFilter className="h-4 w-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuRadioGroup
-                    value={sortKey}
-                    onValueChange={(v) => setSortKey(v as 'created_at' | 'updated_at')}
-                  >
-                    <DropdownMenuRadioItem value="created_at">
-                      Sort by Created
-                    </DropdownMenuRadioItem>
-                    <DropdownMenuRadioItem value="updated_at">
-                      Sort by Updated
-                    </DropdownMenuRadioItem>
-                  </DropdownMenuRadioGroup>
-                </DropdownMenuContent>
-              </DropdownMenu>
-              <SideBarAddProjectButton />
-            </span>
-          </span>
+          {sidebarMode === 'agent' && <SideBarAgentHeader />}
         </SidebarHeader>
 
-        {/* Thread list — selectedAgent is single source of truth */}
         <SidebarContent className="min-w-0 max-w-full overflow-x-hidden gap-0 px-0">
-          {acpActive ? (
-            <SideBarAcpTab onStartNewSession={handleStartNewAcpSessionForProject} />
-          ) : selectedAgent === 'codex' ? (
-            <SideBarCodexTab onCreateNewThread={handleCreateNewThreadForProject} />
-          ) : (
-            <SideBarClaudeTab onStartNewSession={handleStartNewCcSessionForProject} />
-          )}
+          {sidebarMode === 'agent' ? <SideBarAgentList /> : <SideBarBotPane />}
         </SidebarContent>
 
         <SidebarFooter className="flex-row items-center p-0 min-w-0 max-w-full overflow-x-hidden">

--- a/src/components/layout/SideBarAgentPane.tsx
+++ b/src/components/layout/SideBarAgentPane.tsx
@@ -1,0 +1,163 @@
+import { BarChart2, ListFilter, Package2, Timer } from 'lucide-react';
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AgentSwitcher } from '@/components/agent';
+import { useNewThread, useThreadList } from '@/components/codex/hooks';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useSidebar } from '@/components/ui/sidebar';
+import { useCCSessionManager } from '@/hooks/useCCSessionManager';
+import { useLayoutStore } from '@/stores';
+import { useAcpStore } from '@/stores/useAcpStore';
+import { useAgentSettingsStore } from '@/stores/useAgentSettingsStore';
+import { useWorkspaceStore } from '@/stores/useWorkspaceStore';
+import { NewAgentButton } from '../common/NewAgentButton';
+import { SideBarAddProjectButton } from './SideBarAddProjectButton';
+import { SideBarPinnedList } from './SideBarPinnedList';
+import { SideBarAcpTab, SideBarClaudeTab, SideBarCodexTab } from './SideBarTab';
+
+const focusCCInput = () => window.dispatchEvent(new Event('cc-input-focus-request'));
+
+// Shared class for nav buttons (Automations / Marketplace)
+const navBtnBase = 'justify-start gap-2 rounded-md border px-2.5';
+const navBtnActive = 'border-border bg-accent/70 text-accent-foreground';
+const navBtnInactive = 'border-transparent hover:border-border/60';
+const navBtnCls = (active: boolean) => `${navBtnBase} ${active ? navBtnActive : navBtnInactive}`;
+
+/** The Agent tab's header: the nav actions, pinned projects and agent switcher. */
+export function SideBarAgentHeader() {
+  const { t } = useTranslation('sidebar');
+  const { selectedAgent } = useAgentSettingsStore();
+  const { setView, view } = useLayoutStore();
+  const { open: isSidebarOpen } = useSidebar();
+  const { sortKey, setSortKey } = useThreadList({
+    enabled: isSidebarOpen && selectedAgent === 'codex',
+  });
+
+  const currentThreadSortLabel = sortKey === 'created_at' ? 'Created' : 'Updated';
+
+  return (
+    <>
+      {/* Nav actions */}
+      <div className="flex flex-col">
+        <NewAgentButton showLabel />
+        <Button
+          variant="ghost"
+          size="sm"
+          className={navBtnCls(view === 'plugins')}
+          onClick={() => setView('plugins')}
+        >
+          <Package2 className="h-4 w-4" />
+          {t('plugins')}
+        </Button>
+
+        <Button
+          variant="ghost"
+          size="sm"
+          className={navBtnCls(view === 'automations')}
+          onClick={() => setView('automations')}
+        >
+          <Timer className="h-4 w-4" />
+          {t('automations')}
+        </Button>
+
+        <Button
+          variant="ghost"
+          size="sm"
+          className={navBtnCls(view === 'insights')}
+          onClick={() => setView('insights')}
+        >
+          <BarChart2 className="h-4 w-4" />
+          {t('insights')}
+        </Button>
+
+        <SideBarPinnedList />
+      </div>
+
+      {/* Tab switcher row */}
+      <span className="flex justify-between">
+        <AgentSwitcher className="flex gap-2" />
+
+        <span className="flex gap-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                title={`Filter threads (current: ${currentThreadSortLabel})`}
+              >
+                <ListFilter className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuRadioGroup
+                value={sortKey}
+                onValueChange={(v) => setSortKey(v as 'created_at' | 'updated_at')}
+              >
+                <DropdownMenuRadioItem value="created_at">Sort by Created</DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="updated_at">Sort by Updated</DropdownMenuRadioItem>
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <SideBarAddProjectButton />
+        </span>
+      </span>
+    </>
+  );
+}
+
+/** The Agent tab's list — `selectedAgent` is the single source of truth. */
+export function SideBarAgentList() {
+  const { cwd, setCwd } = useWorkspaceStore();
+  const { setSelectedAgent, selectedAgent } = useAgentSettingsStore();
+  const acpActive = useAcpStore((s) => s.active);
+  const { setView, setActiveSidebarTab } = useLayoutStore();
+  const { handleNewThread } = useNewThread();
+  const { handleNewSession } = useCCSessionManager();
+
+  const handleCreateNewThreadForProject = useCallback(
+    (project: string) => {
+      if (project !== cwd) setCwd(project);
+      void handleNewThread();
+    },
+    [cwd, handleNewThread, setCwd]
+  );
+
+  const handleStartNewAcpSessionForProject = useCallback(
+    (directory: string) => {
+      setView('agent');
+      setCwd(directory);
+      // `restart` tears down the connection and asks the composer to reconnect
+      // in the new workspace.
+      useAcpStore.getState().restart();
+    },
+    [setCwd, setView]
+  );
+
+  const handleStartNewCcSessionForProject = useCallback(
+    async (directory: string) => {
+      setSelectedAgent('cc');
+      setActiveSidebarTab('cc');
+      setView('agent');
+      setCwd(directory);
+      await handleNewSession();
+      focusCCInput();
+    },
+    [handleNewSession, setActiveSidebarTab, setCwd, setSelectedAgent, setView]
+  );
+
+  if (acpActive) {
+    return <SideBarAcpTab onStartNewSession={handleStartNewAcpSessionForProject} />;
+  }
+  if (selectedAgent === 'codex') {
+    return <SideBarCodexTab onCreateNewThread={handleCreateNewThreadForProject} />;
+  }
+  return <SideBarClaudeTab onStartNewSession={handleStartNewCcSessionForProject} />;
+}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -68,6 +68,9 @@ export const en = {
   },
   sidebar: {
     newChat: 'New Chat',
+    agent: 'Agent',
+    bot: 'Bot',
+    newBot: 'New Bot',
     plugins: 'Plugins',
     automations: 'Automations',
     insights: 'Insights',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -70,6 +70,9 @@ export const fr = {
   },
   sidebar: {
     newChat: 'Nouvelle discussion',
+    agent: 'Agent',
+    bot: 'Bot',
+    newBot: 'Nouveau bot',
     plugins: 'Plugins',
     automations: 'Automatisations',
     insights: 'Aperçus',

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -60,6 +60,9 @@ export const ja = {
     unknownError: '不明',
   },
   sidebar: {
+    agent: 'エージェント',
+    bot: 'ボット',
+    newBot: '新しいボット',
     usage: '使用状況',
     settings: '設定',
     login: 'ログイン',

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -68,6 +68,9 @@ export const zh = {
   },
   sidebar: {
     newChat: '新聊天',
+    agent: '智能体',
+    bot: '机器人',
+    newBot: '新建机器人',
     plugins: '插件',
     automations: '自动化',
     insights: '洞察',

--- a/src/services/apiAdapt/acp.ts
+++ b/src/services/apiAdapt/acp.ts
@@ -1,4 +1,4 @@
-import { getJson, postJson, postNoContent } from './shared';
+import { getJson, postJson, postJsonWithOptions, postNoContent } from './shared';
 
 export type AcpAgentDef = {
   id: string;
@@ -7,6 +7,13 @@ export type AcpAgentDef = {
   args: string[];
   env: Record<string, string>;
   available: boolean;
+  /**
+   * The agent's own binary resolved, rather than the `npx` download fallback.
+   * `available` is true whenever *anything* can be spawned — with Node
+   * installed that is every npm-published agent — so a caller asking "is this
+   * installed?" wants this instead.
+   */
+  local?: boolean;
 };
 
 export type AcpAuthMethod = {
@@ -82,12 +89,34 @@ export async function acpListAgents() {
   return await getJson<AcpAgentDef[]>('/api/acp/agents');
 }
 
-export async function acpStart(agentId: string, cwd: string, custom?: AcpAgentDef) {
-  return await postJson<AcpStartResult>('/api/acp/start', {
-    agent_id: agentId,
-    cwd,
-    custom: custom ?? null,
-  });
+/**
+ * Install an agent's npm package globally. Returns the re-resolved def, whose
+ * `available` says whether it now runs from PATH.
+ */
+export async function acpInstallAgent(agentId: string) {
+  return await postJson<AcpAgentDef>('/api/acp/install-agent', { agent_id: agentId });
+}
+
+/**
+ * `custom` replaces the preset with a definition of its own — how a bot gets
+ * its own process, with its persona in the environment. `botId` files every
+ * session the connection opens under that bot instead of under the project.
+ */
+export async function acpStart(agentId: string, cwd: string, custom?: AcpAgentDef, botId?: string) {
+  // Every caller already turns a rejection into its own UI (a toast, or —
+  // for a bot whose keke can't spawn — an inline install prompt instead of
+  // one); the generic "Request failed" toast this helper would otherwise
+  // show first only duplicates or preempts that.
+  return await postJsonWithOptions<AcpStartResult>(
+    '/api/acp/start',
+    {
+      agent_id: agentId,
+      cwd,
+      custom: custom ?? null,
+      bot_id: botId ?? null,
+    },
+    { suppressToast: true }
+  );
 }
 
 /**
@@ -125,6 +154,7 @@ export async function acpNewSession(connectionId: string, cwd: string) {
 
 /** A persisted session, as listed in the sidebar. */
 export type AcpSessionRecord = {
+  botId?: string | null;
   sessionId: string;
   agentId: string;
   agentTitle: string | null;

--- a/src/services/apiAdapt/bots.ts
+++ b/src/services/apiAdapt/bots.ts
@@ -1,0 +1,94 @@
+import type { AcpSessionRecord } from './acp';
+import { postJson } from './shared';
+
+/** How much a bot may do on its own. Maps onto keke's approval policy and sandbox mode. */
+export type BotTrustLevel = 'read_only' | 'ask' | 'autonomous';
+
+/**
+ * A bot as the database stores it. The list-shaped fields arrive as JSON
+ * strings, exactly as the column holds them — use `parseBotList` to read one.
+ */
+export type Bot = {
+  id: string;
+  name: string;
+  title: string | null;
+  avatar: string;
+  color: string;
+  agentId: string;
+  provider: string | null;
+  model: string | null;
+  reasoningEffort: string | null;
+  cwd: string;
+  systemPrompt: string | null;
+  trustLevel: BotTrustLevel;
+  approvedTools: string;
+  mcpServers: string;
+  pinned: boolean;
+  archived: boolean;
+  notificationsEnabled: boolean;
+  unreadCount: number;
+  lastViewedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/** A stored JSON array column. A corrupt value reads as empty rather than throwing. */
+export function parseBotList(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((item) => typeof item === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Only the fields being changed. Anything omitted keeps its stored value. */
+export type BotPatch = Partial<{
+  name: string;
+  title: string;
+  avatar: string;
+  color: string;
+  provider: string;
+  model: string;
+  reasoningEffort: string;
+  cwd: string;
+  systemPrompt: string;
+  trustLevel: BotTrustLevel;
+  approvedTools: string[];
+  mcpServers: string[];
+  pinned: boolean;
+  archived: boolean;
+  notificationsEnabled: boolean;
+  unreadCount: number;
+  lastViewedAt: string;
+}>;
+
+export async function listBots(includeArchived = false) {
+  return await postJson<Bot[]>('/api/bots/list', { include_archived: includeArchived });
+}
+
+export async function createBot(params: {
+  id: string;
+  name: string;
+  avatar: string;
+  color: string;
+  cwd: string;
+  agentId?: string;
+  trustLevel?: BotTrustLevel;
+}) {
+  return await postJson<Bot>('/api/bots/create', params);
+}
+
+export async function updateBot(id: string, patch: BotPatch) {
+  return await postJson<Bot>('/api/bots/update', { id, ...patch });
+}
+
+export async function deleteBot(id: string) {
+  await postJson<null>('/api/bots/delete', { id });
+}
+
+/** A bot's conversations, newest first. Reads the database only. */
+export async function listBotSessions(botId: string, limit?: number) {
+  return await postJson<AcpSessionRecord[]>('/api/bots/sessions', { botId, limit });
+}

--- a/src/services/apiAdapt/index.ts
+++ b/src/services/apiAdapt/index.ts
@@ -3,6 +3,7 @@ import { isDesktopTauri } from './shared';
 
 export * from './acp';
 export * from './automation';
+export * from './bots';
 
 export * from './cc';
 export * from './codex';

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -7,8 +7,9 @@ export {
 export * from './useAcpStore';
 export * from './useAgentCenterStore';
 export * from './useAgentSettingsStore';
+export * from './useBotUiStore';
 export * from './useEditorStore';
 export * from './useInputStore';
-export { useLayoutStore } from './useLayoutStore';
+export { type SidebarMode, useLayoutStore } from './useLayoutStore';
 export * from './usePluginStore';
 export * from './useWorkspaceStore';

--- a/src/stores/useAcpStore.ts
+++ b/src/stores/useAcpStore.ts
@@ -66,6 +66,8 @@ interface AcpStore {
   connecting: boolean;
   running: boolean;
   entries: AcpEntry[];
+  /** Set by `sealChunk`: the next chunk starts a new entry. */
+  chunkSealed: boolean;
   permission: AcpPermissionRequest | null;
 
   /** Session controls advertised by the agent. */
@@ -120,6 +122,12 @@ interface AcpStore {
   setEntries: (entries: AcpEntry[]) => void;
   /** Append to the last entry when it has the same streaming role, else push. */
   appendChunk: (role: 'agent' | 'thought', text: string) => void;
+  /**
+   * Keep the next chunk from merging into the last entry. Used at the seam
+   * between two replayed transcripts, whose chunks are separate turns even
+   * though they share a role.
+   */
+  sealChunk: () => void;
   /** Merge a `tool_call` / `tool_call_update`: absent fields keep their value. */
   upsertToolCall: (tool: {
     toolCallId: string;
@@ -148,6 +156,7 @@ const cleared = {
   connecting: false,
   running: false,
   entries: [],
+  chunkSealed: false,
   permission: null,
   modes: null,
   models: null,
@@ -169,6 +178,7 @@ export const useAcpStore = create<AcpStore>((set) => ({
   connecting: false,
   running: false,
   entries: [],
+  chunkSealed: false,
   permission: null,
   modes: null,
   models: null,
@@ -229,16 +239,18 @@ export const useAcpStore = create<AcpStore>((set) => ({
   setRunning: (running) => set({ running }),
   setPermission: (permission) => set({ permission }),
   addEntry: (entry) => set((s) => ({ entries: [...s.entries, entry] })),
-  setEntries: (entries) => set({ entries }),
+  setEntries: (entries) => set({ entries, chunkSealed: false }),
+
+  sealChunk: () => set({ chunkSealed: true }),
 
   appendChunk: (role, text) =>
     set((s) => {
       const last = s.entries[s.entries.length - 1];
-      if (last && last.role === role) {
+      if (last && last.role === role && !s.chunkSealed) {
         const updated = { ...last, text: last.text + text };
-        return { entries: [...s.entries.slice(0, -1), updated] };
+        return { entries: [...s.entries.slice(0, -1), updated], chunkSealed: false };
       }
-      return { entries: [...s.entries, { id: newId(), role, text }] };
+      return { entries: [...s.entries, { id: newId(), role, text }], chunkSealed: false };
     }),
 
   upsertToolCall: ({ toolCallId, title, status, kind, content, locations, rawInput, rawOutput }) =>

--- a/src/stores/useAcpStore.ts
+++ b/src/stores/useAcpStore.ts
@@ -40,6 +40,10 @@ export type AcpPermissionOption = { optionId: string; name: string; kind?: strin
 export type AcpPermissionRequest = {
   requestId: string;
   title: string;
+  /** The tool call's category (`read`, `edit`, `execute`, ...) when the agent
+   * reported one. Coarse on purpose: it is the unit a standing "always allow"
+   * can be about, where a per-call title never repeats. */
+  toolKind?: string;
   options: AcpPermissionOption[];
 };
 

--- a/src/stores/useBotOptionsStore.ts
+++ b/src/stores/useBotOptionsStore.ts
@@ -1,0 +1,65 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type {
+  AcpAuthMethod,
+  AcpConfigOption,
+  AcpInitializeResult,
+  AcpModelState,
+  AcpSessionResult,
+} from '@/services/apiAdapt/acp';
+
+/**
+ * The accounts, models and reasoning efforts keke last advertised.
+ *
+ * keke only reports these over a live connection, but a bot is configured
+ * before it has ever run — including right after "New bot". Caching the last
+ * live catalogue lets the settings dialog drive the very same `AcpChoiceMenu`
+ * the composer uses, instead of falling back to free-text inputs.
+ *
+ * Stored in the agent's own shapes so no translation is needed at either end.
+ */
+interface BotOptionsStore {
+  authMethods: AcpAuthMethod[];
+  /** Model / effort options only; `currentValue` here is meaningless. */
+  configOptions: AcpConfigOption[];
+  models: AcpModelState | null;
+  setCatalogue: (catalogue: {
+    authMethods: AcpAuthMethod[];
+    configOptions: AcpConfigOption[];
+    models: AcpModelState | null;
+  }) => void;
+}
+
+export const useBotOptionsStore = create<BotOptionsStore>()(
+  persist(
+    (set) => ({
+      authMethods: [],
+      configOptions: [],
+      models: null,
+      setCatalogue: ({ authMethods, configOptions, models }) =>
+        set((state) => ({
+          // A connection that advertises nothing must not wipe what we know.
+          authMethods: authMethods.length ? authMethods : state.authMethods,
+          configOptions: configOptions.length ? configOptions : state.configOptions,
+          models: models?.availableModels.length ? models : state.models,
+        })),
+    }),
+    { name: 'bot-options-storage', version: 2, migrate: () => ({}) as Partial<BotOptionsStore> }
+  )
+);
+
+/** Record what a freshly opened keke session offers. */
+export function captureBotOptions(
+  initialize: AcpInitializeResult | null,
+  session: AcpSessionResult | null
+) {
+  useBotOptionsStore.getState().setCatalogue({
+    authMethods: initialize?.authMethods ?? [],
+    // `mode` is per-conversation, not a bot setting; trust level covers it.
+    configOptions: (session?.configOptions ?? []).filter(
+      (o) =>
+        o.category === 'model' || o.category === 'model_config' || o.category === 'thought_level'
+    ),
+    models: session?.models ?? null,
+  });
+}

--- a/src/stores/useBotUiStore.ts
+++ b/src/stores/useBotUiStore.ts
@@ -21,6 +21,13 @@ interface BotUiStore {
   connectionByBot: Record<string, string>;
   setBotConnection: (botId: string, connectionId: string) => void;
   clearBotConnection: (botId: string) => void;
+  /**
+   * Which bots have a turn in flight. The ACP store's `running` is a single
+   * flag for the one visible conversation, so it cannot answer this while the
+   * user is looking at another bot.
+   */
+  runningByBot: Record<string, boolean>;
+  setBotRunning: (botId: string, running: boolean) => void;
   /** The ACP session currently open for each bot, so a return restores it. */
   sessionByBot: Record<string, string>;
   setBotSession: (botId: string, sessionId: string) => void;
@@ -64,6 +71,9 @@ export const useBotUiStore = create<BotUiStore>((set) => ({
       const { [botId]: _removed, ...connectionByBot } = state.connectionByBot;
       return { connectionByBot };
     }),
+  runningByBot: {},
+  setBotRunning: (botId, running) =>
+    set((state) => ({ runningByBot: { ...state.runningByBot, [botId]: running } })),
   sessionByBot: {},
   setBotSession: (botId, sessionId) =>
     set((state) => ({ sessionByBot: { ...state.sessionByBot, [botId]: sessionId } })),

--- a/src/stores/useBotUiStore.ts
+++ b/src/stores/useBotUiStore.ts
@@ -1,0 +1,72 @@
+import { create } from 'zustand';
+import type { Bot } from '@/services/apiAdapt/bots';
+
+/**
+ * Client state for the Bot tab. The bots themselves live in the database, so
+ * nothing here is persisted: this is the cache the sidebar renders from, plus
+ * the live connections that must survive switching between bots.
+ */
+interface BotUiStore {
+  bots: Bot[];
+  setBots: (bots: Bot[]) => void;
+  /** Replace one bot in place, after an update round-trip. */
+  upsertBot: (bot: Bot) => void;
+  removeBot: (id: string) => void;
+  selectedBotId: string | null;
+  setSelectedBotId: (id: string | null) => void;
+  /**
+   * The keke process each bot is talking to. Kept so switching back to a bot
+   * reuses its process instead of paying for a spawn and a fresh session.
+   */
+  connectionByBot: Record<string, string>;
+  setBotConnection: (botId: string, connectionId: string) => void;
+  clearBotConnection: (botId: string) => void;
+  /** The ACP session currently open for each bot, so a return restores it. */
+  sessionByBot: Record<string, string>;
+  setBotSession: (botId: string, sessionId: string) => void;
+  /**
+   * `keke` (or its `npx` fallback) resolved on PATH but actually spawning it
+   * failed anyway — e.g. a packaged app's PATH doesn't match the shell's.
+   * Once this happens the composer treats keke as unusable, the same as the
+   * preset never resolving, rather than retrying and toasting on every send.
+   */
+  kekeSpawnFailed: boolean;
+  setKekeSpawnFailed: (failed: boolean) => void;
+}
+
+export const useBotUiStore = create<BotUiStore>((set) => ({
+  bots: [],
+  setBots: (bots) => set({ bots }),
+  upsertBot: (bot) =>
+    set((state) => ({
+      bots: state.bots.some((b) => b.id === bot.id)
+        ? state.bots.map((b) => (b.id === bot.id ? bot : b))
+        : [...state.bots, bot],
+    })),
+  removeBot: (id) =>
+    set((state) => {
+      const { [id]: _connection, ...connectionByBot } = state.connectionByBot;
+      const { [id]: _session, ...sessionByBot } = state.sessionByBot;
+      return {
+        bots: state.bots.filter((bot) => bot.id !== id),
+        connectionByBot,
+        sessionByBot,
+        selectedBotId: state.selectedBotId === id ? null : state.selectedBotId,
+      };
+    }),
+  selectedBotId: null,
+  setSelectedBotId: (selectedBotId) => set({ selectedBotId }),
+  connectionByBot: {},
+  setBotConnection: (botId, connectionId) =>
+    set((state) => ({ connectionByBot: { ...state.connectionByBot, [botId]: connectionId } })),
+  clearBotConnection: (botId) =>
+    set((state) => {
+      const { [botId]: _removed, ...connectionByBot } = state.connectionByBot;
+      return { connectionByBot };
+    }),
+  sessionByBot: {},
+  setBotSession: (botId, sessionId) =>
+    set((state) => ({ sessionByBot: { ...state.sessionByBot, [botId]: sessionId } })),
+  kekeSpawnFailed: false,
+  setKekeSpawnFailed: (kekeSpawnFailed) => set({ kekeSpawnFailed }),
+}));

--- a/src/stores/useLayoutStore.ts
+++ b/src/stores/useLayoutStore.ts
@@ -17,7 +17,10 @@ export type viewType =
   | 'plugins'
   | 'settings'
   | 'usage'
-  | 'insights';
+  | 'insights'
+  | 'bot';
+
+export type SidebarMode = 'agent' | 'bot';
 
 export type RightPanelTab = 'diff' | 'tasks' | 'todo' | 'terminal' | 'webpreview' | 'files';
 
@@ -38,6 +41,9 @@ interface LayoutStore {
   toggleRightPanelFocused: () => void;
   activeSidebarTab: AgentType;
   setActiveSidebarTab: (tab: AgentType) => void;
+  /** Which half of the sidebar is showing: the agent workspaces, or the bots. */
+  sidebarMode: SidebarMode;
+  setSidebarMode: (mode: SidebarMode) => void;
   activeRightPanelTab: RightPanelTab | null;
   setActiveRightPanelTab: (tab: RightPanelTab) => void;
   // Right panel tabs currently open in the header bar; closable independently of activeRightPanelTab.
@@ -82,6 +88,8 @@ export const useLayoutStore = create<LayoutStore>()(
         set((state) => ({ isRightPanelFocused: !state.isRightPanelFocused })),
       activeSidebarTab: 'codex',
       setActiveSidebarTab: (tab) => set({ activeSidebarTab: tab }),
+      sidebarMode: 'agent',
+      setSidebarMode: (sidebarMode) => set({ sidebarMode }),
       activeRightPanelTab: 'diff',
       setActiveRightPanelTab: (tab) =>
         set((state) => ({
@@ -144,7 +152,7 @@ export const useLayoutStore = create<LayoutStore>()(
     }),
     {
       name: 'layout-storage',
-      version: 6,
+      version: 7,
       partialize: (state) => ({
         isSidebarOpen: state.isSidebarOpen,
         isRightPanelOpen: state.isRightPanelOpen,
@@ -152,6 +160,7 @@ export const useLayoutStore = create<LayoutStore>()(
         view: state.view,
         isRightPanelFocused: state.isRightPanelFocused,
         activeSidebarTab: state.activeSidebarTab,
+        sidebarMode: state.sidebarMode,
         activeRightPanelTab: state.activeRightPanelTab,
         openRightPanelTabs: state.openRightPanelTabs,
         diffWordWrap: state.diffWordWrap,
@@ -175,6 +184,12 @@ export const useLayoutStore = create<LayoutStore>()(
               (tab: string) => (tab === 'note' ? 'todo' : tab)
             );
           }
+        }
+        if (version < 7 && persistedState) {
+          // The Bot tab is new, so a store written before it has no mode and
+          // must land on the sidebar it was last actually showing.
+          persistedState.sidebarMode = 'agent';
+          if (persistedState.view === 'bot') persistedState.view = 'agent';
         }
         return persistedState;
       },

--- a/web/src/handlers/acp.rs
+++ b/web/src/handlers/acp.rs
@@ -11,6 +11,10 @@ pub(crate) struct AcpStartParams {
     pub cwd: String,
     #[serde(default)]
     pub custom: Option<AcpAgentDef>,
+    /// Set when the Bot tab starts a bot's own agent process, so every session
+    /// the connection opens is filed under that bot.
+    #[serde(default)]
+    pub bot_id: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -103,13 +107,30 @@ pub(crate) async fn api_acp_list_agents() -> Json<Vec<AcpAgentDef>> {
     Json(codexia_acp::list_agents())
 }
 
+#[derive(Deserialize)]
+pub(crate) struct AcpInstallAgentParams {
+    pub agent_id: String,
+}
+
+/// Install an agent's npm package globally, and hand back the re-resolved
+/// def so the caller can see it is now available without a restart.
+pub(crate) async fn api_acp_install_agent(
+    Json(params): Json<AcpInstallAgentParams>,
+) -> Result<Json<AcpAgentDef>, ErrorResponse> {
+    tokio::task::spawn_blocking(move || codexia_acp::install_preset(&params.agent_id))
+        .await
+        .map_err(|e| err(e.to_string()))?
+        .map(Json)
+        .map_err(err)
+}
+
 pub(crate) async fn api_acp_start(
     AxumState(state): AxumState<WebServerState>,
     Json(params): Json<AcpStartParams>,
 ) -> Result<Json<AcpStartResult>, ErrorResponse> {
     state
         .acp_state
-        .start(&params.agent_id, &params.cwd, params.custom)
+        .start(&params.agent_id, &params.cwd, params.custom, params.bot_id)
         .await
         .map(Json)
         .map_err(err)

--- a/web/src/handlers/bots.rs
+++ b/web/src/handlers/bots.rs
@@ -1,0 +1,102 @@
+use axum::Json;
+use serde::Deserialize;
+
+use codexia_db::acp_sessions::AcpSessionRecord;
+use codexia_db::bots::{BotPatch, BotRecord};
+
+use crate::types::ErrorResponse;
+
+fn err(e: String) -> ErrorResponse {
+    ErrorResponse { error: e }
+}
+
+#[derive(Deserialize)]
+pub(crate) struct ListBotsParams {
+    #[serde(default)]
+    pub include_archived: bool,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CreateBotParams {
+    pub id: String,
+    pub name: String,
+    pub avatar: String,
+    pub color: String,
+    pub cwd: String,
+    /// Which ACP preset backs the bot. Defaults to keke, the only one the Bot
+    /// tab offers today.
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    #[serde(default)]
+    pub trust_level: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct UpdateBotParams {
+    pub id: String,
+    #[serde(flatten)]
+    pub patch: BotPatch,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct BotIdParams {
+    pub id: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BotSessionsParams {
+    pub bot_id: String,
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+pub(crate) async fn api_list_bots(
+    Json(params): Json<ListBotsParams>,
+) -> Result<Json<Vec<BotRecord>>, ErrorResponse> {
+    codexia_db::bots::list_bots(params.include_archived)
+        .map(Json)
+        .map_err(err)
+}
+
+pub(crate) async fn api_create_bot(
+    Json(params): Json<CreateBotParams>,
+) -> Result<Json<BotRecord>, ErrorResponse> {
+    codexia_db::bots::create_bot(
+        &params.id,
+        &params.name,
+        &params.avatar,
+        &params.color,
+        params.agent_id.as_deref().unwrap_or("keke"),
+        &params.cwd,
+        params.trust_level.as_deref().unwrap_or("ask"),
+    )
+    .map(Json)
+    .map_err(err)
+}
+
+pub(crate) async fn api_update_bot(
+    Json(params): Json<UpdateBotParams>,
+) -> Result<Json<BotRecord>, ErrorResponse> {
+    codexia_db::bots::update_bot(&params.id, &params.patch)
+        .map(Json)
+        .map_err(err)
+}
+
+pub(crate) async fn api_delete_bot(
+    Json(params): Json<BotIdParams>,
+) -> Result<Json<()>, ErrorResponse> {
+    codexia_db::bots::delete_bot(&params.id).map(Json).map_err(err)
+}
+
+/// One bot's conversations, newest first. A table read: listing a bot must
+/// never wake its agent process.
+pub(crate) async fn api_bot_sessions(
+    Json(params): Json<BotSessionsParams>,
+) -> Result<Json<Vec<AcpSessionRecord>>, ErrorResponse> {
+    codexia_db::acp_sessions::list_bot_sessions(&params.bot_id, params.limit.unwrap_or(100))
+        .map(Json)
+        .map_err(err)
+}

--- a/web/src/handlers/mod.rs
+++ b/web/src/handlers/mod.rs
@@ -13,6 +13,7 @@ mod file;
 mod git;
 mod openapp;
 mod automation;
+mod bots;
 mod insights;
 mod skills;
 mod settings;
@@ -21,6 +22,7 @@ mod terminal;
 mod types;
 
 pub(super) use acp::*;
+pub(super) use bots::*;
 pub(super) use cc::*;
 pub(super) use codex::*;
 pub(super) use file::*;

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -11,10 +11,11 @@ use tower_http::services::{ServeDir, ServeFile};
 use super::{
     handlers::{
         api_account_rate_limits, api_allow_sleep, api_archive_thread, api_unarchive_thread, api_canonicalize_path,
-        api_acp_list_agents, api_acp_start, api_acp_prompt, api_acp_cancel,
+        api_acp_list_agents, api_acp_install_agent, api_acp_start, api_acp_prompt, api_acp_cancel,
         api_acp_authenticate, api_acp_new_session, api_acp_respond_permission, api_acp_stop,
         api_acp_set_mode, api_acp_set_model, api_acp_set_config_option,
         api_acp_load_session, api_acp_list_sessions, api_acp_get_session, api_acp_delete_session,
+        api_list_bots, api_create_bot, api_update_bot, api_delete_bot, api_bot_sessions,
         api_cc_list_projects, api_cc_mcp_add, api_cc_mcp_disable, api_cc_mcp_enable,
         api_cc_mcp_get, api_cc_mcp_list, api_cc_mcp_remove,
         api_cc_connect, api_cc_disconnect, api_cc_get_installed_skills,
@@ -368,6 +369,7 @@ pub fn create_router(state: WebServerState) -> Router {
             post(api_git_has_worktree_changes),
         )
         .route("/api/acp/agents", get(api_acp_list_agents))
+        .route("/api/acp/install-agent", post(api_acp_install_agent))
         .route("/api/acp/start", post(api_acp_start))
         .route("/api/acp/prompt", post(api_acp_prompt))
         .route("/api/acp/cancel", post(api_acp_cancel))
@@ -382,6 +384,11 @@ pub fn create_router(state: WebServerState) -> Router {
         .route("/api/acp/set-config-option", post(api_acp_set_config_option))
         .route("/api/acp/respond-permission", post(api_acp_respond_permission))
         .route("/api/acp/stop", post(api_acp_stop))
+        .route("/api/bots/list", post(api_list_bots))
+        .route("/api/bots/create", post(api_create_bot))
+        .route("/api/bots/update", post(api_update_bot))
+        .route("/api/bots/delete", post(api_delete_bot))
+        .route("/api/bots/sessions", post(api_bot_sessions))
         .route("/api/cc/connect", post(api_cc_connect))
         .route("/api/cc/send-message", post(api_cc_send_message))
         .route("/api/cc/disconnect", post(api_cc_disconnect))


### PR DESCRIPTION
This PR adds bot mode functionality to the Codexia desktop application, including:

- A sidebar that lists existing sessions and allows starting a new one directly from the sidebar.
- A sidebar trigger and drag‑drop workspace functionality added to the chat header.
- A Tauri file dialog to pick a workspace folder.
- Per‑bot conversation isolation, ensuring each bot keeps its own conversation history.
- Provider and model selection via the ACP menu.
- A settings dialog that opens automatically after creating a new bot.
- A new **Bot** tab displaying keke‑backed chats.

The implementation consists of 7 commits that extend the codebase to support bot‑oriented interactions, improving usability and organization of chat sessions.