### PR TITLE
feat: add optional you.com search integration

### DIFF
--- a/src/features/mcp/DefaultMcpServers.tsx
+++ b/src/features/mcp/DefaultMcpServers.tsx
@@ -30,6 +30,15 @@ export function DefaultMcpServers({ servers, onServerAdded }: DefaultMcpServersP
         url: 'https://mcp.deepwiki.com/mcp',
       },
     },
+    {
+      name: 'you-search',
+      description:
+        'Web search for coding agents from You.com: current web results and URL content extraction with citations. No account or API key required.',
+      config: {
+        type: 'http' as const,
+        url: 'https://api.you.com/mcp?profile=free',
+      },
+    },
   ];
 
   const handleAddDefaultServer = async (defaultServer: (typeof defaultServers)[0]) => {


### PR DESCRIPTION
## What

Adds [You.com](https://you.com)'s keyless `you-search` MCP server to the **Quick Add servers** list:

- name: `you-search`
- endpoint: `https://api.you.com/mcp?profile=free`
- no account or API key needed

This gives agent sessions one-click access to current web search and URL content extraction with citations — useful when a Codex/Claude session needs up-to-date docs, release notes, or library answers that aren't in the local repo.

## Why this shape

I noticed the Quick Add list already ships keyless HTTP servers (deepwiki, parallel-search), so I followed that exact pattern — one entry in `defaultServers`, nothing else. It's strictly opt-in: nothing is added to a user's config until they click **Add**, and the card greys out once the server exists. The `HttpMcpServerConfig` type doesn't carry headers, so I used You.com's keyless free profile rather than the authenticated endpoint — same no-signup experience as the other entries.

For users who want the fuller toolset (`you-contents`, `you-research`), the authenticated server `https://api.you.com/mcp` can be added manually via the Add panel with a `YDC_API_KEY` bearer header (API keys at [you.com/platform/api-keys](https://you.com/platform/api-keys)). The broader skills/plugin packaging for agent platforms lives at [youdotcom-oss/agent-skills](https://github.com/youdotcom-oss/agent-skills) if that's ever useful here.

## Validation

- `bun install` + `bun run build` (tsc + vite) — pass
- `bun run typecheck` — pass
- `bun run test` — 20/20 pass
- `biome check` on the touched file — clean (one pre-existing `info` on an untouched line)
- Endpoint liveness: MCP `initialize` POST against `https://api.you.com/mcp?profile=free` returns HTTP 200

Happy to adjust the description wording or drop the entry entirely if you'd rather keep the Quick Add list curated to a smaller set.
